### PR TITLE
Fix: #76. Reformat yaml files using update_schema.py

### DIFF
--- a/data-new/BuildAndDeployment/Sub-Dimensions.yaml
+++ b/data-new/BuildAndDeployment/Sub-Dimensions.yaml
@@ -1,12 +1,11 @@
----
 _meta:
-  label: "Build and deployment"
-  icon: "Build and Deployment.png"
+  label: Build and deployment
+  icon: Build and Deployment.png
   description: |-
     A markdown description of this dimension.
 _yaml_references:
   tools:
-    ci-cd: &ci-cd CI/CD tools, eg. Jenkins 
+    ci-cd: &ci-cd CI/CD tools, eg. Jenkins
 
 Build:
   Building and testing of artifacts in virtual environments:
@@ -15,12 +14,12 @@ Build:
       and 3rd party libraries are used. These might be malicious as a result of
       vulnerable libraries or because they are altered during the delivery phase.
     risk:
-      - |-
-        While building and testing artifacts, third party systems, application frameworks
-        and 3rd party libraries are used. These might be malicious as a result of
-        vulnerable libraries or because they are altered during the delivery phase.
-    measure: Each step during within the build and testing phase is performed in
-      a separate virtual environments, which is destroyed afterward.
+    - |-
+      While building and testing artifacts, third party systems, application frameworks
+      and 3rd party libraries are used. These might be malicious as a result of
+      vulnerable libraries or because they are altered during the delivery phase.
+    measure: Each step during within the build and testing phase is performed in a
+      separate virtual environments, which is destroyed afterward.
     meta:
       implementationGuide: Depending on your environment, usage of virtual machines
         or container technology is a good way. After the build, the filesystem should
@@ -36,9 +35,9 @@ Build:
     - *ci-cd
     references:
       samm2:
-      - "samm2:i-secure-build|A|2"
+      - i-secure-build|A|2
       iso27001-2017:
-      - "iso27001-2017:14.2.6"
+      - iso27001-2017:14.2.6
   Defined build process:
     risk:
     - Performing builds without a defined process is error prone; for example, as
@@ -64,7 +63,8 @@ Build:
       - 12.1.1
       - 14.2.2
   Signing of code:
-    risk: Unauthorized manipulation of source code might be difficult to spot.
+    risk:
+    - Unauthorized manipulation of source code might be difficult to spot.
     measure: Digitally signing commits helps to prevent unauthorized manipulation
       of source code.
     difficultyOfImplementation:
@@ -73,7 +73,7 @@ Build:
       resources: 2
     usefulness: 3
     level: 3
-    implementation: ~
+    implementation: []
     dependsOn:
     - Defined build process
     references:
@@ -82,8 +82,9 @@ Build:
       iso27001-2017:
       - 14.2.6
   Signing of artifacts:
-    risk: Unauthorized manipulation of artifacts might be difficult to spot. For
-      example, this may result in images with malicious code in the Docker registry.
+    risk:
+    - Unauthorized manipulation of artifacts might be difficult to spot. For example,
+      this may result in images with malicious code in the Docker registry.
     measure: Digitally signing artifacts for all steps during the build and especially
       docker images, helps to ensure their integrity.
     difficultyOfImplementation:
@@ -106,40 +107,44 @@ Build:
       - 14.2.6
 Deployment:
   Backup before deployment:
-    risk: If errors are experienced during the deployment process you want to deploy
-      an old release. However, due to changes in the database this is often unfeasible.
-    measure: Performing automated backups before deployment can help facilitate
-      deployments whilst testing the backup restore processes.
+    risk:
+    - If errors are experienced during the deployment process you want to deploy an
+      old release. However, due to changes in the database this is often unfeasible.
+    measure: Performing automated backups before deployment can help facilitate deployments
+      whilst testing the backup restore processes.
     difficultyOfImplementation:
       knowledge: 1
       time: 2
       resources: 1
     usefulness: 4
     level: 2
-    implementation: A complete database backup might be performed*. For large and
-      complex environments, a Point in Time Recovery for databases should be implemented.
+    implementation:
+    - A complete database backup might be performed*. For large and complex environments
+    - ' a Point in Time Recovery for databases should be implemented.'
     dependsOn:
     - Defined deployment process
     references:
       samm:
       - OE2-A
       samm2:
-        - TODO
+      - TODO
       iso27001-2017:
-      - "12.3"
+      - '12.3'
       - 14.2.6
   Blue/Green Deployment:
-    risk: A new artifacts version can have unknown defects.
+    risk:
+    - A new artifacts version can have unknown defects.
     measure: By having multiple production environments, a deployment can be performant
-      on the first environment to spot possible defects before it is deployment
-      in the production environment(s)
+      on the first environment to spot possible defects before it is deployment in
+      the production environment(s)
     difficultyOfImplementation:
       knowledge: 1
       time: 2
       resources: 1
     usefulness: 2
     level: 4
-    implementation: <a href='https://martinfowler.com/bliki/BlueGreenDeployment.html'>Blue/Green
+    implementation:
+    - <a href='https://martinfowler.com/bliki/BlueGreenDeployment.html'>Blue/Green
       Deployments</a>
     dependsOn:
     - Smoke Test
@@ -154,24 +159,28 @@ Deployment:
       - 12.5.1
       - 14.2.9
   Defined deployment process:
-    risk: Deployments without a defined process are error prone thus allowing old
-      or untested artifact to be deployed.
-    measure: A defined deployment process significantly lowers the likelihood of
-      errors during the deployment phase.
+    risk:
+    - Deployments without a defined process are error prone thus allowing old or untested
+      artifact to be deployed.
+    measure: A defined deployment process significantly lowers the likelihood of errors
+      during the deployment phase.
     difficultyOfImplementation:
       knowledge: 2
       time: 2
       resources: 1
     usefulness: 4
     level: 1
-    implementation: Jenkins, Docker
+    implementation:
+    - Jenkins
+    - ' Docker'
     references:
       samm2: i-secure-deployment|A|1
       iso27001-2017:
       - 12.1.1
       - 14.2.2
   Environment depending configuration parameters:
-    risk: Attackers who compromise source code can see confidential access information
+    risk:
+    - Attackers who compromise source code can see confidential access information
       like database credentials.
     measure: Configuration parameters are set for each environment not in the source
       code.
@@ -181,7 +190,7 @@ Deployment:
       resources: 1
     usefulness: 4
     level: 2
-    implementation: ""
+    implementation: []
     references:
       samm:
       - SA2-A
@@ -192,8 +201,8 @@ Deployment:
       - 14.2.6
   Handover of confidential parameters:
     risk:
-    - Attackers who compromise a system can see confidential access information
-      like database credentials.
+    - Attackers who compromise a system can see confidential access information like
+      database credentials.
     - Parameters are often used to set credentials, for example by starting containers
       or applications; these parameters can often be seen by any one listing running
       processes on the target system.
@@ -206,7 +215,7 @@ Deployment:
       resources: 1
     usefulness: 4
     level: 3
-    implementation: ""
+    implementation: []
     dependsOn:
     - Environment depending configuration parameters
     references:
@@ -219,7 +228,8 @@ Deployment:
       - 9.4.1
       - 10.1.2
   Rolling update on deployment:
-    risk: While a deployment is performed, the application can not be reached.
+    risk:
+    - While a deployment is performed, the application can not be reached.
     measure: A deployment without downtime is performed*.
     difficultyOfImplementation:
       knowledge: 2
@@ -227,7 +237,10 @@ Deployment:
       resources: 2
     usefulness: 2
     level: 3
-    implementation: Docker, Webserver, rolling update
+    implementation:
+    - Docker
+    - ' Webserver'
+    - ' rolling update'
     dependsOn:
     - Defined deployment process
     samm2: i-secure-deployment|A|1
@@ -236,8 +249,9 @@ Deployment:
     - 14.2.2
     - 17.2.1
   Same artifact for environments:
-    risk: Building of an artifact for different environments means that an untested
-      artifact might reach the production environment.
+    risk:
+    - Building of an artifact for different environments means that an untested artifact
+      might reach the production environment.
     measure: Building an artifact once and deploying it to different environments
       means that only tested artifacts are allowed to reach the production environment
     difficultyOfImplementation:
@@ -246,7 +260,8 @@ Deployment:
       resources: 1
     usefulness: 4
     level: 3
-    implementation: Docker
+    implementation:
+    - Docker
     dependsOn:
     - Defined build process
     samm: OE2-A
@@ -256,8 +271,9 @@ Deployment:
     - 14.2.8
     - 12.1.4
   Usage of feature toggles:
-    risk: By using environment dependent configuration, some parameters will not
-      be tested correctly. i.e. <pre>if (host == 'production') {} else {}</pre>
+    risk:
+    - By using environment dependent configuration, some parameters will not be tested
+      correctly. i.e. <pre>if (host == 'production') {} else {}</pre>
     measure: Usage of environment independent configuration parameter, called feature
       toggles, helps to enhance the test coverage. Only what has been tested, goes
       to production.
@@ -267,7 +283,8 @@ Deployment:
       resources: 1
     usefulness: 2
     level: 3
-    implementation: Docker
+    implementation:
+    - Docker
     dependsOn:
     - Same artifact for environments
     samm: EG1-B
@@ -277,31 +294,33 @@ Deployment:
     - 14.2.9
     - 12.1.4
   Usage of trusted images:
-    risk: Developers or operations might start random images in the production cluster
+    risk:
+    - Developers or operations might start random images in the production cluster
       which have malicious code or known vulnerabilities.
     measure: Create image assessment criteria, perform an evaluation of images and
       create a whitelist of artifacts/container images/virtual machine images.
-    implementation: Kubernetes Admission Controller can whitelist registries and/or
-      whitelist a signing key.
+    implementation:
+    - Kubernetes Admission Controller can whitelist registries and/or whitelist a
+      signing key.
     difficultyOfImplementation:
       knowledge: 1
       time: 1
       resources: 1
     usefulness: 3
     level: 2
-    samm2: samm2:i-secure-deployment|A|2
+    samm2: i-secure-deployment|A|2
     iso27001-2017:
     - 15.1.1
     - 15.1.2
     - 15.1.3
     - 14.1.3
   Inventory of running artifacts:
-    risk: In case a vulnerability of severity high or critical exists, it needs
-      to be known where an artifacts with that vulnerability is deployed with which
-      dependencies.
+    risk:
+    - In case a vulnerability of severity high or critical exists, it needs to be
+      known where an artifacts with that vulnerability is deployed with which dependencies.
     measure: A documented inventory or a possibility to gather the needed information
-      (e.g. the documentation of which script needs to be run by whom) must be
-      in place.
+      (e.g. the documentation of which script needs to be run by whom) must be in
+      place.
     dependsOn:
     - Defined deployment process
     difficultyOfImplementation:
@@ -312,11 +331,13 @@ Deployment:
     level: 3
     samm2: o-incident-management|TODO
     iso27001-2017:
-    - "8.1"
-    - "8.2"
+    - '8.1'
+    - '8.2'
+    implementation: []
 Patch Management:
   A patch policy is defined:
-    risk: Vulnerabilities in running containers stay for long and might get exploited.
+    risk:
+    - Vulnerabilities in running containers stay for long and might get exploited.
     measure: A patch policy for all artifacts (e.g. in images) is defined. How often
       is an image rebuilt?
     difficultyOfImplementation:
@@ -330,9 +351,10 @@ Patch Management:
     - 12.6.1
     - 12.5.1
     - 14.2.5
+    implementation: []
   Nightly build of images:
-    risk: Vulnerabilities in running containers stay for too long and might get
-      exploited.
+    risk:
+    - Vulnerabilities in running containers stay for too long and might get exploited.
     measure: Images are built at least nightly.
     difficultyOfImplementation:
       knowledge: 3
@@ -343,11 +365,13 @@ Patch Management:
     samm2: o-environment-management|B|1
     iso27001-2017:
     - 12.6.1
+    implementation: []
   Automated PRs for patches:
-    risk: Known vulnerabilities components might stay for long and get exploited,
-      even when a patch is available.
-    measure: Fast patching of third party component is needed. The DevOps way is
-      to have an automated pull request for new components. This includes <ul> <li>Applications</li><li>Virtualized
+    risk:
+    - Known vulnerabilities components might stay for long and get exploited, even
+      when a patch is available.
+    measure: Fast patching of third party component is needed. The DevOps way is to
+      have an automated pull request for new components. This includes <ul> <li>Applications</li><li>Virtualized
       operating system components (e.g. container images)</li> <li>Operating Systems</li><li>Infrastructure
       as Code/GitOps (e.g. argocd)</li> </ul>
     difficultyOfImplementation:
@@ -364,10 +388,11 @@ Patch Management:
     - <a href="https://dependabot.com/">dependabot</a>
     - Jenkins
   Usage of a maximum lifetime for images:
-    risk: Vulnerabilities in images of running containers stay for too long and
-      might get exploited. Long running containers have potential memory leaks.
-      A compromised container might get killed by restarting the container (e.g.
-      in case the attacker has not reached the persistence layer).
+    risk:
+    - Vulnerabilities in images of running containers stay for too long and might
+      get exploited. Long running containers have potential memory leaks. A compromised
+      container might get killed by restarting the container (e.g. in case the attacker
+      has not reached the persistence layer).
     measure: The periodically built images are deployed minimum every 30 days (better
       hourly/daily/weekly). Meaning an image is not in production for longer than
       30 days.
@@ -380,9 +405,10 @@ Patch Management:
     samm2: o-environment-management|B|1
     iso27001-2017:
     - 12.6.1
+    implementation: []
   Usage of a short maximum lifetime for images:
-    risk: Vulnerabilities in running containers stay for too long and might get
-      exploited.
+    risk:
+    - Vulnerabilities in running containers stay for too long and might get exploited.
     measure: Nightly built images are deployed at minimum every 1 day.
     difficultyOfImplementation:
       knowledge: 3
@@ -394,21 +420,22 @@ Patch Management:
     iso27001-2017:
     - 12.6.1
     implementation:
-    - Sample concept:<br/>(1) each container has a set lifetime and is killed /
-      replaced with a new container multiple times a day where you have some form
-      of a graceful replacement to ensure no (short) service outage will occur to
-      the end users.<br/>(2) twice a day a rebuild of images is done. The rebuilds
-      are put into a automated testing pipeline. If the testing has no blocking
-      issues the new images will be released for deployment during the next "restart"
-      of a container. What has to be done, is to ensure the new containers are deployed
-      in some canary deployment manner, this will ensure that if (and only if) something
-      buggy has been introduced which breaks functionality the canary deployment
-      will make sure the "older version" is being used and not the buggy newer one.
+    - Sample concept:<br/>(1) each container has a set lifetime and is killed / replaced
+      with a new container multiple times a day where you have some form of a graceful
+      replacement to ensure no (short) service outage will occur to the end users.<br/>(2)
+      twice a day a rebuild of images is done. The rebuilds are put into a automated
+      testing pipeline. If the testing has no blocking issues the new images will
+      be released for deployment during the next "restart" of a container. What has
+      to be done, is to ensure the new containers are deployed in some canary deployment
+      manner, this will ensure that if (and only if) something buggy has been introduced
+      which breaks functionality the canary deployment will make sure the "older version"
+      is being used and not the buggy newer one.
   Reduction of the attack surface:
-    risk: Components, dependencies, files or file access rights might have vulnerabilities,
+    risk:
+    - Components, dependencies, files or file access rights might have vulnerabilities,
       but the they are not needed.
-    measure: Removal of unneeded components, dependencies, files or file access
-      rights. For container images the usage of distroless images is recommended.
+    measure: Removal of unneeded components, dependencies, files or file access rights.
+      For container images the usage of distroless images is recommended.
     difficultyOfImplementation:
       knowledge: 3
       time: 3
@@ -422,4 +449,3 @@ Patch Management:
     implementation:
     - <a href="https://github.com/GoogleContainerTools/distroless">Distroless</a>
     - <a href="https://getfedora.org/coreos?stream=stable">Fedora CoreOS</a>
-...

--- a/data-new/CultureAndOrganization/Design.yaml
+++ b/data-new/CultureAndOrganization/Design.yaml
@@ -1,7 +1,7 @@
----
 Design:
   Conduction of advanced threat modeling:
-    risk: Inadequate identification of business and technical risks.
+    risk:
+    - Inadequate identification of business and technical risks.
     measure: Threat modeling is performed by using reviewing user stories and producing
       security driven data flow diagrams.
     difficultyOfImplementation:
@@ -29,9 +29,11 @@ Design:
     - may be part of risk assessment
     - 8.2.1
     - 14.2.1
+    implementation: []
   Conduction of simple threat modeling on business level:
-    risk: Business related threats are discovered too late in the development and
-      deployment process.
+    risk:
+    - Business related threats are discovered too late in the development and deployment
+      process.
     measure: Threat modeling of business functionality is performed during the product
       backlog creation to facilitate early detection of security defects.
     difficultyOfImplementation:
@@ -46,9 +48,11 @@ Design:
     - may be part of risk assessment
     - 8.2.1
     - 14.2.1
+    implementation: []
   Conduction of simple threat modeling on technical level:
-    risk: Technical related threats are discovered too late in the development and
-      deployment process.
+    risk:
+    - Technical related threats are discovered too late in the development and deployment
+      process.
     measure: Threat modeling of technical features is performed during the product
       sprint planning.
     difficultyOfImplementation:
@@ -101,7 +105,8 @@ Design:
     - 8.2.1
     - 14.2.1
   Creation of advanced abuse stories:
-    risk: Simple user stories are not going deep enough. Relevant security considerations
+    risk:
+    - Simple user stories are not going deep enough. Relevant security considerations
       are performed. Security flaws are discovered too late in the development and
       deployment process
     measure: Advanced abuse stories are created as part of threat modeling activities.
@@ -120,12 +125,14 @@ Design:
     - 6.1.5
     - may be part of risk assessment
     - 8.1.2
-    implementation: <a href='https://www.owasp.org/index.php/Agile_Software_Development:_Don%27t_Forget_EVIL_User_Stories'>Don't
+    implementation:
+    - <a href='https://www.owasp.org/index.php/Agile_Software_Development:_Don%27t_Forget_EVIL_User_Stories'>Don't
       Forget EVIL User Stories</a> and <a href='http://safecode.org/publication/SAFECode_Agile_Dev_Security0712.pdf'>Practical
       Security Stories and Security Tasks for Agile Development Environments</a>
   Creation of simple abuse stories:
-    risk: User stories mostly don't consider security implications. Security flaws
-      are discovered too late in the development and deployment process.
+    risk:
+    - User stories mostly don't consider security implications. Security flaws are
+      discovered too late in the development and deployment process.
     measure: Abuse stories are created during the creation of user stories.
     difficultyOfImplementation:
       knowledge: 2
@@ -140,11 +147,13 @@ Design:
     - 6.1.5
     - may be part of risk assessment
     - 8.1.2
-    implementation: <a href='https://www.owasp.org/index.php/Agile_Software_Development:_Don%27t_Forget_EVIL_User_Stories'>Don't
+    implementation:
+    - <a href='https://www.owasp.org/index.php/Agile_Software_Development:_Don%27t_Forget_EVIL_User_Stories'>Don't
       Forget EVIL User Stories</a> and <a href='http://safecode.org/publication/SAFECode_Agile_Dev_Security0712.pdf'>Practical
       Security Stories and Security Tasks for Agile Development Environments</a>
   Information security targets are communicated:
-    risk: Employees don't known their organizations security targets. Therefore security
+    risk:
+    - Employees don't known their organizations security targets. Therefore security
       is not considered during development and administration as much as it should
       be.
     measure: Transparent and timely communication of the security targets by senior
@@ -159,4 +168,4 @@ Design:
     iso27001-2017:
     - 5.1.1
     - 7.2.1
-...
+    implementation: []

--- a/data-new/CultureAndOrganization/EducationAndGuidance.yaml
+++ b/data-new/CultureAndOrganization/EducationAndGuidance.yaml
@@ -90,10 +90,9 @@ Education and Guidance:
     iso27001-2017:
     - 7.2.2
     implementation:
-    - Often
-    - ' external employees are not invited for internal trainings. This activity focuses
+    - Often, external employees are not invited for internal trainings. This activity focuses
       on providing security trainings to internal as well as external employees. It
-      is conducted every two weeks for around one hour.'
+      is conducted every two weeks for around one hour.
   Each team has a security champion:
     risk:
     - No one feels directly responsible for security and the security champion does

--- a/data-new/CultureAndOrganization/EducationAndGuidance.yaml
+++ b/data-new/CultureAndOrganization/EducationAndGuidance.yaml
@@ -233,8 +233,7 @@ Education and Guidance:
       time: 5
       resources: 1
     implementation:
-    - Security SME are involved in discussion for requirements analysis
-    - ' software design and sprint planning to provide guidance and suggestions.'
+    - Security SME are involved in discussion for requirements analysis, software design and sprint planning to provide guidance and suggestions.
     usefulness: 5
     level: 4
     samm: EG2-B

--- a/data-new/CultureAndOrganization/EducationAndGuidance.yaml
+++ b/data-new/CultureAndOrganization/EducationAndGuidance.yaml
@@ -1,9 +1,9 @@
----
 Education and Guidance:
   Ad-Hoc Security trainings for software developers:
-    risk: Understanding security is hard and personnel needs to be trained on it.
-      Otherwise, flaws like an SQL Injection might be introduced into the software
-      which might get exploited.
+    risk:
+    - Understanding security is hard and personnel needs to be trained on it. Otherwise,
+      flaws like an SQL Injection might be introduced into the software which might
+      get exploited.
     measure: Provide security awareness training for all personnel involved in software
       development Ad-Hoc.
     difficultyOfImplementation:
@@ -21,7 +21,8 @@ Education and Guidance:
     iso27001-2017:
     - 7.2.2
   Regular security training for all:
-    risk: Understanding security is hard.
+    risk:
+    - Understanding security is hard.
     measure: Provide security awareness training for all personnel involved in software
       development on a regular basis like twice in a year for 1-3 days.
     difficultyOfImplementation:
@@ -39,7 +40,8 @@ Education and Guidance:
       Shop</a> on a "hacking Friday"
     - https://cheatsheetseries.owasp.org/
   Security consulting on request:
-    risk: Not asking a security expert when questions regarding security appear might
+    risk:
+    - Not asking a security expert when questions regarding security appear might
       lead to flaws.
     measure: Security consulting to teams is given on request. The security consultants
       can be internal or external.
@@ -55,8 +57,10 @@ Education and Guidance:
     - 6.1.1
     - 6.1.4
     - 6.1.5
+    implementation: []
   Regular security training of security champions:
-    risk: Understanding security is hard, even for security champions.
+    risk:
+    - Understanding security is hard, even for security champions.
     measure: Regular security training of security champions.
     evidence: |
       - Process Documentation: TODO
@@ -71,8 +75,10 @@ Education and Guidance:
     iso27001-2017:
     - security champions are missing in ISO 27001
     - 7.2.2
+    implementation: []
   Regular security training for everyone:
-    risk: Understanding security is hard, for internal as well as external employees.
+    risk:
+    - Understanding security is hard, for internal as well as external employees.
     measure: Regular security training for everyone.
     difficultyOfImplementation:
       knowledge: 3
@@ -83,12 +89,15 @@ Education and Guidance:
     samm: EG2-B
     iso27001-2017:
     - 7.2.2
-    implementation: Often, external employees are not invited for internal trainings.
-      This activity focuses on providing security trainings to internal as well as
-      external employees. It is conducted every two weeks for around one hour.
+    implementation:
+    - Often
+    - ' external employees are not invited for internal trainings. This activity focuses
+      on providing security trainings to internal as well as external employees. It
+      is conducted every two weeks for around one hour.'
   Each team has a security champion:
-    risk: No one feels directly responsible for security and the security champion
-      does not have enough time to allocate to each team.
+    risk:
+    - No one feels directly responsible for security and the security champion does
+      not have enough time to allocate to each team.
     measure: Each team defines an individual to be responsible for security. These
       individuals are often referred to as 'security champions'
     difficultyOfImplementation:
@@ -102,10 +111,11 @@ Education and Guidance:
     - security champions are missing in ISO 27001 most likely
     - 7.2.1
     - 7.2.2
-    implementation: 
+    implementation:
     - OWASP Security Champions Playbook: https://github.com/c0rdis/security-champions-playbook
   Security-Lessoned-Learned:
-    risk: After an incident, a similar incident might reoccur.
+    risk:
+    - After an incident, a similar incident might reoccur.
     measure: Running a 'lessons learned' session after an incident helps drive continuous
       improvement. Regular meetings with security champions are a good place to share
       and discuss lessons learned.
@@ -118,9 +128,11 @@ Education and Guidance:
     samm: IM-3, ST-3, SR2-B
     iso27001-2017:
     - 16.1.6
+    implementation: []
   Conduction of collaborative security checks with developers and system administrators:
-    risk: Security checks by external companies do not increase the understanding
-      of an application/system for internal employees.
+    risk:
+    - Security checks by external companies do not increase the understanding of an
+      application/system for internal employees.
     measure: Periodically security reviews of source code (SCA), in which security
       SME, developers and operations are involved, are effective at increasing the
       robustness of software and the security knowledge of the teams involved.
@@ -136,8 +148,10 @@ Education and Guidance:
     - 7.2.2
     - 12.6.1
     - 12.7.1
+    implementation: []
   Conduction of collaborative team security checks:
-    risk: Development teams limited insight over security practices.
+    risk:
+    - Development teams limited insight over security practices.
     measure: Mutual security testing the security of other teams project enhances
       security awareness and knowledge.
     difficultyOfImplementation:
@@ -150,8 +164,10 @@ Education and Guidance:
     iso27001-2017:
     - Mutual security testing is not explicitly required in ISO 27001 may be
     - 7.2.2
+    implementation: []
   Conduction of build-it, break-it, fix-it contests:
-    risk: Understanding security is hard, even for security champions and the conduction
+    risk:
+    - Understanding security is hard, even for security champions and the conduction
       of security training often focuses on breaking a component instead of building
       a component secure.
     measure: The build-it, break-it, fix-it contest allows to train people with security
@@ -165,9 +181,11 @@ Education and Guidance:
     level: 3
     iso27001-2017:
     - 7.2.2
-    implementation: https://builditbreakit.org/
+    implementation:
+    - https://builditbreakit.org/
   Conduction of war games:
-    risk: Understanding incident response plans during an incident is hard and ineffective.
+    risk:
+    - Understanding incident response plans during an incident is hard and ineffective.
     measure: War Games like activities help train for incidents. Security SMEs create
       attack scenarios in a testing environment enabling the trainees to learn how
       to react in case of an incident.
@@ -180,10 +198,12 @@ Education and Guidance:
     iso27001-2017:
     - ware games are not explicitly required in ISO 27001 may be
     - 7.2.2
-    - "16.1"
+    - '16.1'
     - 16.1.5
+    implementation: []
   Reward of good communication:
-    risk: Employees are not getting excited about security.
+    risk:
+    - Employees are not getting excited about security.
     measure: Good communication and transparency encourages cross-organizational support.
       Gamification of security is also known to help, examples include T-Shirts, mugs,
       cups, giftcards and 'High-Fives'.
@@ -203,7 +223,8 @@ Education and Guidance:
       Project</a>
     - https://owaspsamm.org/presentations/OWASP_Top_10_Maturity_Categories_for_Security_Champions.pptx
   Aligning security in teams:
-    risk: The concept of Security Champions might suggest that only he/she is responsible
+    risk:
+    - The concept of Security Champions might suggest that only he/she is responsible
       for security. However, everyone in the project team should be responsible for
       security.
     measure: By aligning security SME with project teams, a higher security standard
@@ -212,11 +233,11 @@ Education and Guidance:
       knowledge: 4
       time: 5
       resources: 1
-    implementation: Security SME are involved in discussion for requirements analysis,
-      software design and sprint planning to provide guidance and suggestions.
+    implementation:
+    - Security SME are involved in discussion for requirements analysis
+    - ' software design and sprint planning to provide guidance and suggestions.'
     usefulness: 5
     level: 4
     samm: EG2-B
     iso27001-2017:
     - 7.1.1
-...

--- a/data-new/CultureAndOrganization/Process.yaml
+++ b/data-new/CultureAndOrganization/Process.yaml
@@ -1,8 +1,8 @@
----
 Process:
   Definition of simple BCDR practices for critical components:
-    risk: In case of an emergency, like a power outage, DR actions to perform are
-      not clear. This leads to reaction and remediation delays.
+    risk:
+    - In case of an emergency, like a power outage, DR actions to perform are not
+      clear. This leads to reaction and remediation delays.
     measure: By understanding and documenting a business continuity and disaster recovery
       (BCDR) plan, the overall availability of systems and applications is increased.
       Success factors like responsibilities, Service Level Agreements, Recovery Point
@@ -16,9 +16,10 @@ Process:
     level: 1
     iso27001-2017:
     - 17.1.1
+    implementation: []
   Definition of a change management process:
-    risk: The impact of a change is not controlled because these are not recorded
-      or documented.
+    risk:
+    - The impact of a change is not controlled because these are not recorded or documented.
     measure: Each change of a system is automatically recorded and adequately logged.
     difficultyOfImplementation:
       knowledge: 4
@@ -30,8 +31,10 @@ Process:
     - 14.2.2
     - 12.1.2
     - 12.4.1
+    implementation: []
   Approval by reviewing any new version:
-    risk: An individual might forget to implement security measures to protect source
+    risk:
+    - An individual might forget to implement security measures to protect source
       code or infrastructure components.
     measure: On each new version (e.g. Pull Request) of source code or infrastructure
       components a security peer review of the changes is performed (two eyes principle)
@@ -47,8 +50,10 @@ Process:
     - peer review - four eyes principle is not explicitly required by ISO 27001
     - 6.1.2
     - 14.2.1
+    implementation: []
   Prevention of unauthorized installation:
-    risk: Unapproved components are used.
+    risk:
+    - Unapproved components are used.
     measure: Components must be whitelisted. Regular scans on the docker infrastructure
       (e.g. cluster) need to be performed, to verify that only standardized base images
       are used.
@@ -61,8 +66,7 @@ Process:
     iso27001-2017:
     - 12.5.1
     - 12.6.1
-    implementation: 'Example: All docker images used by teams need to be based on
-      standard images.'
+    implementation:
+    - 'Example: All docker images used by teams need to be based on standard images.'
     comment: By preventing teams from trying out new components, innovation might
       be hampered
-...

--- a/data-new/CultureAndOrganization/_meta.yaml
+++ b/data-new/CultureAndOrganization/_meta.yaml
@@ -1,6 +1,5 @@
----
 _meta:
-  label: "Culture and Organization"
-  icon: "Culture and Org.png"
+  label: Culture and Organization
+  icon: Culture and Org.png
   description: |-
     A markdown description of this dimension.

--- a/data-new/Implementation/ApplicationHardening.yaml
+++ b/data-new/Implementation/ApplicationHardening.yaml
@@ -1,7 +1,7 @@
----
 Application Hardening:
   Application Hardening Level 1:
-    risk: Using an insecure application might lead to a compromised application. This
+    risk:
+    - Using an insecure application might lead to a compromised application. This
       might lead to total data theft or data modification.
     measure: |
       Following frameworks like the
@@ -43,7 +43,8 @@ Application Hardening:
     - hardening is not explicitly covered by ISO 27001 - too specific
     - 13.1.3
   App. Hardening Level 2:
-    risk: Using an insecure application might lead to a compromised application. This
+    risk:
+    - Using an insecure application might lead to a compromised application. This
       might lead to total data theft or data modification.
     measure: |
       Following frameworks like the
@@ -66,7 +67,8 @@ Application Hardening:
     - hardening is not explicitly covered by ISO 27001 - too specific
     - 13.1.3
   App. Hardening Level 3:
-    risk: Using an insecure application might lead to a compromised application. This
+    risk:
+    - Using an insecure application might lead to a compromised application. This
       might lead to total data theft or data modification.
     measure: |
       Following frameworks like the
@@ -90,7 +92,8 @@ Application Hardening:
     - hardening is not explicitly covered by ISO 27001 - too specific
     - 13.1.3
   Full Coverage of App. Hardening Level 3:
-    risk: Using an insecure application might lead to a compromised application. This
+    risk:
+    - Using an insecure application might lead to a compromised application. This
       might lead to total data theft or data modification.
     measure: |
       Following frameworks like the
@@ -113,4 +116,3 @@ Application Hardening:
     iso27001-2017:
     - hardening is not explicitly covered by ISO 27001 - too specific
     - 13.1.3
-...

--- a/data-new/Implementation/InfrastructureHardening.yaml
+++ b/data-new/Implementation/InfrastructureHardening.yaml
@@ -134,7 +134,7 @@ Infrastructure Hardening:
     - Applications are running in virtualized environments
     implementation:
     - seccomp
-    - ' strace'
+    - strace
     samm2: o-environment-management|A|1
     iso27001-2017:
     - system hardening is not explicitly covered by ISO 27001 - too specific

--- a/data-new/Implementation/InfrastructureHardening.yaml
+++ b/data-new/Implementation/InfrastructureHardening.yaml
@@ -1,8 +1,7 @@
----
 Infrastructure Hardening:
   The cluster is hardened:
-    risk: Using default configurations for a cluster environment leads to potential
-      risks.
+    risk:
+    - Using default configurations for a cluster environment leads to potential risks.
     measure: Harden cluster environments according to best practices. Level 1 and
       partially level 2 from hardening practices like 'CIS Kubernetes Bench for Security'
       should considered.
@@ -23,7 +22,8 @@ Infrastructure Hardening:
     - system hardening is not explicitly covered by ISO 27001 - too specific
     - 13.1.3
   Applications are running in virtualized environments:
-    risk: Through a vulnerability in one service on a server, the attacker gains access
+    risk:
+    - Through a vulnerability in one service on a server, the attacker gains access
       to other services running on the same server.
     measure: Applications are running in a dedicated and isolated virtualized environments.
     difficultyOfImplementation:
@@ -36,8 +36,10 @@ Infrastructure Hardening:
     iso27001-2017:
     - virtual environments are not explicitly covered by ISO 27001 - too specific
     - 13.1.3
+    implementation: []
   Checking the sources of used libraries:
-    risk: Application and system libraries can have implementation flaws or deployment
+    risk:
+    - Application and system libraries can have implementation flaws or deployment
       flaws.
     measure: Each libraries source is checked to have a trusted source.
     difficultyOfImplementation:
@@ -52,11 +54,13 @@ Infrastructure Hardening:
     - not explicitly covered by ISO 27001 - too specific
     - 14.2.1
     - 14.2.5
+    implementation: []
   Isolated networks for virtual environments:
-    risk: Virtual environments in default settings are able to access other virtual
-      environments on the network stack. By using virtual machines, it is often possible
-      to connect to other virtual machines. By using docker, one bridge is used by
-      default so that all containers on one host can communicate with each other.
+    risk:
+    - Virtual environments in default settings are able to access other virtual environments
+      on the network stack. By using virtual machines, it is often possible to connect
+      to other virtual machines. By using docker, one bridge is used by default so
+      that all containers on one host can communicate with each other.
     measure: The communication between virtual environments is controlled and regulated.
     difficultyOfImplementation:
       knowledge: 3
@@ -74,7 +78,8 @@ Infrastructure Hardening:
     - virtual environments are not explicitly covered by ISO 27001 - too specific
     - 13.1.3
   Filter outgoing traffic:
-    risk: A compromised infrastructure component might try to send out stolen data.
+    risk:
+    - A compromised infrastructure component might try to send out stolen data.
     measure: Having a whitelist and explicitly allowing egress traffic provides the
       ability to stop unauthorized data leakage.
     difficultyOfImplementation:
@@ -92,7 +97,8 @@ Infrastructure Hardening:
     - virtual environments are not explicitly covered by ISO 27001 - too specific
     - 13.1.3
   Infrastructure as Code:
-    risk: No tracking of changes in systems might lead to errors in the configuration.
+    risk:
+    - No tracking of changes in systems might lead to errors in the configuration.
       In additions, it might lead to unauthorized changes. An examples is jenkins.
     measure: Systems are setup by code. A full environment can be provisioned. In
       addition, software like Jenkins 2 can be setup and configured in in code too.
@@ -103,14 +109,20 @@ Infrastructure Hardening:
       resources: 4
     usefulness: 4
     level: 3
-    implementation: GitOps, Ansible, Chef, Puppet, Jenkinsfile
+    implementation:
+    - GitOps
+    - ' Ansible'
+    - ' Chef'
+    - ' Puppet'
+    - ' Jenkinsfile'
     samm2: o-environment-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.1.1
     - 12.1.2
   Limitation of system calls in virtual environments:
-    risk: System calls in virtual environments like docker can lead to privilege escalation.
+    risk:
+    - System calls in virtual environments like docker can lead to privilege escalation.
     measure: System calls in virtual environments like docker are audited and limited.
     difficultyOfImplementation:
       knowledge: 3
@@ -120,12 +132,15 @@ Infrastructure Hardening:
     level: 4
     dependsOn:
     - Applications are running in virtualized environments
-    implementation: seccomp, strace
+    implementation:
+    - seccomp
+    - ' strace'
     samm2: o-environment-management|A|1
     iso27001-2017:
     - system hardening is not explicitly covered by ISO 27001 - too specific
   Immutable Infrastructure:
-    risk: The availability of IT systems might be disturbed due to components failures
+    risk:
+    - The availability of IT systems might be disturbed due to components failures
     measure: Redundancies in the IT systems
     difficultyOfImplementation:
       knowledge: 2
@@ -137,13 +152,15 @@ Infrastructure Hardening:
     - Infrastructure as Code
     - Usage of <a href="https://semver.org/">Semantic Versioning</a> for components
       like project images
-    implementation: Remove direct access to infrastructure
+    implementation:
+    - Remove direct access to infrastructure
     samm2: o-environment-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 17.2.1
   Microservice-Architecture:
-    risk: Monolithic applications are hard to test.
+    risk:
+    - Monolithic applications are hard to test.
     measure: A microservice-architecture helps to have small components, which are
       more easy to test.
     difficultyOfImplementation:
@@ -156,9 +173,11 @@ Infrastructure Hardening:
     samm2: o-environment-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001
+    implementation: []
   Production near environments are used by developers:
-    risk: In case an errors occurs in production, the developer need to be able to
-      create a production near environment on a local development environment.
+    risk:
+    - In case an errors occurs in production, the developer need to be able to create
+      a production near environment on a local development environment.
     measure: Usage of infrastructure as code helps to create a production near environment.
       The developer needs to be trained in order to setup a local development environment.
       In addition, it should be possible to create production like test data. Often
@@ -178,9 +197,11 @@ Infrastructure Hardening:
     iso27001-2017:
     - 12.1.4
     - 17.2.1
+    implementation: []
   Role based authentication and authorization:
-    risk: Everyone is able to get unauthorized access to information on systems or
-      to modify information unauthorized on systems.
+    risk:
+    - Everyone is able to get unauthorized access to information on systems or to
+      modify information unauthorized on systems.
     measure: The usage of a (role based) access control helps to restrict system access
       to authorized users.
     difficultyOfImplementation:
@@ -189,7 +210,9 @@ Infrastructure Hardening:
       resources: 1
     usefulness: 3
     level: 3
-    implementation: Directory Service, Plugins
+    implementation:
+    - Directory Service
+    - ' Plugins'
     dependsOn:
     - Defined deployment process
     - Defined build process
@@ -197,8 +220,9 @@ Infrastructure Hardening:
     iso27001-2017:
     - 9.4.1
   2FA:
-    risk: One factor authentication is more vulnerable to brute force attacks and
-      is considered less secure.
+    risk:
+    - One factor authentication is more vulnerable to brute force attacks and is considered
+      less secure.
     measure: Two factor authentication for all privileged accounts on systems and
       applications
     difficultyOfImplementation:
@@ -207,7 +231,11 @@ Infrastructure Hardening:
       resources: 3
     usefulness: 4
     level: 3
-    implementation: Smartcard, YubiKey, SMS, TOTP
+    implementation:
+    - Smartcard
+    - ' YubiKey'
+    - ' SMS'
+    - ' TOTP'
     samm2: TODO
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
@@ -215,7 +243,8 @@ Infrastructure Hardening:
     - 9.4.2
     - 14.2.5
   Simple access control for systems:
-    risk: Attackers a gaining access to internal systems and application interfaces
+    risk:
+    - Attackers a gaining access to internal systems and application interfaces
     measure: All internal systems are using simple authentication
     difficultyOfImplementation:
       knowledge: 3
@@ -225,15 +254,19 @@ Infrastructure Hardening:
     level: 1
     dependsOn:
     - Defined deployment process
-    implementation: HTTP-Basic Authentication, TLS, VPN
+    implementation:
+    - HTTP-Basic Authentication
+    - ' TLS'
+    - ' VPN'
     samm: EH1-B
     samm2: o-environment-management|A|1
     iso27001-2017:
     - 9.4.1
   Usage of a chaos monkey:
-    risk: Due to manual changes on a system, they are not replaceable anymore. In
-      case of a crash it might happen that a planned redundant system is unavailable.
-      In addition, it is hard to replay manual changes.
+    risk:
+    - Due to manual changes on a system, they are not replaceable anymore. In case
+      of a crash it might happen that a planned redundant system is unavailable. In
+      addition, it is hard to replay manual changes.
     measure: A randomized periodically shutdown of systems makes sure, that nobody
       will perform manual changes to a system.
     difficultyOfImplementation:
@@ -246,8 +279,10 @@ Infrastructure Hardening:
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 17.1.3
+    implementation: []
   Usage of security by default for components:
-    risk: Components (images, libraries, applications) are not hardened.
+    risk:
+    - Components (images, libraries, applications) are not hardened.
     measure: Hardening of components is important, specially for image on which other
       teams base on. Hardening should be performed on the operation system and on
       the services inside (e.g. Nginx or a Java-Application).
@@ -257,15 +292,19 @@ Infrastructure Hardening:
       resources: 1
     usefulness: 3
     level: 2
-    implementation: 'For applications: Check default encoding, managing secrets, crypto,
-      authentication'
+    implementation:
+    - 'For applications: Check default encoding'
+    - ' managing secrets'
+    - ' crypto'
+    - ' authentication'
     dependsOn:
     - Defined build process
     samm2: o-environment-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
   Usage of test and production environments:
-    risk: Security tests are not running regularly because test environments are missing
+    risk:
+    - Security tests are not running regularly because test environments are missing
     measure: A production and a production like environment is used
     difficultyOfImplementation:
       knowledge: 3
@@ -280,8 +319,10 @@ Infrastructure Hardening:
     - not explicitly covered by ISO 27001 - too specific
     - 12.1.4
     - 17.2.1
+    implementation: []
   versioning:
-    risk: Changes to production systems can not be undone.
+    risk:
+    - Changes to production systems can not be undone.
     measure: versioning of artifacts related to production environments. For example
       Jenkins configuration, docker images, system provisioning code.
     difficultyOfImplementation:
@@ -298,9 +339,11 @@ Infrastructure Hardening:
     - 12.1.1
     - 12.1.2
     - 14.2.2
+    implementation: []
   Virtual environments are limited:
-    risk: Denial of service (internally by an attacker or unintentionally by a bug)
-      on one service effects other services
+    risk:
+    - Denial of service (internally by an attacker or unintentionally by a bug) on
+      one service effects other services
     measure: All virtual environments are using resource limits on hard disks, memory
       and CPU
     difficultyOfImplementation:
@@ -317,4 +360,4 @@ Infrastructure Hardening:
     - 12.1.3
     - 13.1.3
     - 17.2.1
-...
+    implementation: []

--- a/data-new/Implementation/InfrastructureHardening.yaml
+++ b/data-new/Implementation/InfrastructureHardening.yaml
@@ -233,9 +233,9 @@ Infrastructure Hardening:
     level: 3
     implementation:
     - Smartcard
-    - ' YubiKey'
-    - ' SMS'
-    - ' TOTP'
+    - YubiKey
+    - SMS
+    - TOTP
     samm2: TODO
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific

--- a/data-new/Implementation/InfrastructureHardening.yaml
+++ b/data-new/Implementation/InfrastructureHardening.yaml
@@ -111,10 +111,10 @@ Infrastructure Hardening:
     level: 3
     implementation:
     - GitOps
-    - ' Ansible'
-    - ' Chef'
-    - ' Puppet'
-    - ' Jenkinsfile'
+    - Ansible
+    - Chef
+    - Puppet
+    - Jenkinsfile
     samm2: o-environment-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
@@ -212,7 +212,7 @@ Infrastructure Hardening:
     level: 3
     implementation:
     - Directory Service
-    - ' Plugins'
+    - Plugins
     dependsOn:
     - Defined deployment process
     - Defined build process
@@ -256,8 +256,7 @@ Infrastructure Hardening:
     - Defined deployment process
     implementation:
     - HTTP-Basic Authentication
-    - ' TLS'
-    - ' VPN'
+    - VPN
     samm: EH1-B
     samm2: o-environment-management|A|1
     iso27001-2017:
@@ -293,10 +292,10 @@ Infrastructure Hardening:
     usefulness: 3
     level: 2
     implementation:
-    - 'For applications: Check default encoding'
-    - ' managing secrets'
-    - ' crypto'
-    - ' authentication'
+    - For applications: Check default encoding
+    - managing secrets
+    - crypto
+    - authentication
     dependsOn:
     - Defined build process
     samm2: o-environment-management|A|1

--- a/data-new/InformationGathering/Logging.yaml
+++ b/data-new/InformationGathering/Logging.yaml
@@ -1,9 +1,9 @@
----
 Logging:
   Centralized application logging:
-    risk: Local stored logs can be unauthorized manipulated by attackers with system
-      access or might be corrupt after an incident. In addition, it is hard to perform
-      an correlation of logs. This leads attacks, which can be performed silently.
+    risk:
+    - Local stored logs can be unauthorized manipulated by attackers with system access
+      or might be corrupt after an incident. In addition, it is hard to perform an
+      correlation of logs. This leads attacks, which can be performed silently.
     measure: A centralized logging system is used and applications logs (including
       application exceptions) are shipped to it.
     difficultyOfImplementation:
@@ -20,9 +20,11 @@ Logging:
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.4.1
+    implementation: []
   PII logging concept:
-    risk: Personal identifiable information (PII) is logged and the law of GDPR is
-      not followed.
+    risk:
+    - Personal identifiable information (PII) is logged and the law of GDPR is not
+      followed.
     measure: A concept how to log PII is documented and applied.
     difficultyOfImplementation:
       knowledge: 1
@@ -30,14 +32,19 @@ Logging:
       resources: 1
     usefulness: 1
     level: 1
-    implementation: rsyslog, logstash, fluentd, bash
+    implementation:
+    - rsyslog
+    - ' logstash'
+    - ' fluentd'
+    - ' bash'
     samm2: o-incident-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.4.1
     - 18.1.1
   Logging of security events:
-    risk: No track of security-relevant events makes it harder to analyze an incident.
+    risk:
+    - No track of security-relevant events makes it harder to analyze an incident.
     measure: Security-relevant events like login/logout or creation, change, deletion
       of users should be logged.
     difficultyOfImplementation:
@@ -48,13 +55,18 @@ Logging:
     level: 1
     dependsOn:
     - PII logging concept
-    implementation: rsyslog, logstash, fluentd, bash
+    implementation:
+    - rsyslog
+    - ' logstash'
+    - ' fluentd'
+    - ' bash'
     samm2: o-incident-management|A|1
     iso27001-2017:
     - 12.4.1
   Centralized system logging:
-    risk: Local stored system logs can be unauthorized manipulated by attackers or
-      might be corrupt after an incident. In addition, it is hard to perform a aggregation
+    risk:
+    - Local stored system logs can be unauthorized manipulated by attackers or might
+      be corrupt after an incident. In addition, it is hard to perform a aggregation
       of logs.
     measure: By using centralized logging logs are protected against unauthorized
       modification.
@@ -64,13 +76,16 @@ Logging:
       resources: 1
     usefulness: 2
     level: 1
-    implementation: rsyslog, Logstash
+    implementation:
+    - rsyslog
+    - ' Logstash'
     samm2: o-incident-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.4.1
   Correlation of security events:
-    risk: Detection of security related events with hints on different systems/tools/metrics
+    risk:
+    - Detection of security related events with hints on different systems/tools/metrics
       is not possible.
     measure: Events are correlated on one system. For example the correlation and
       visualization of failed login attempts combined with successful login attempts.
@@ -87,9 +102,11 @@ Logging:
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.4.1
+    implementation: []
   Visualized logging:
-    risk: System and application protocols are not visualized properly which leads
-      to no or very limited logging assessment. Specially developers might have difficulty
+    risk:
+    - System and application protocols are not visualized properly which leads to
+      no or very limited logging assessment. Specially developers might have difficulty
       to read applications logs with unusually tools like the Linux tool 'cat'
     measure: Protocols are visualized in a simple to use real time monitoring system.
       The GUI gives the ability to search for special attributes in the protocol.
@@ -102,9 +119,9 @@ Logging:
     dependsOn:
     - Centralized system logging
     - Centralized application logging
-    implementation: ELK-Stack
+    implementation:
+    - ELK-Stack
     samm2: o-incident-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.4.1
-...

--- a/data-new/InformationGathering/Logging.yaml
+++ b/data-new/InformationGathering/Logging.yaml
@@ -34,9 +34,9 @@ Logging:
     level: 1
     implementation:
     - rsyslog
-    - ' logstash'
-    - ' fluentd'
-    - ' bash'
+    - logstash
+    - fluentd
+    - bash
     samm2: o-incident-management|A|1
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
@@ -57,9 +57,9 @@ Logging:
     - PII logging concept
     implementation:
     - rsyslog
-    - ' logstash'
-    - ' fluentd'
-    - ' bash'
+    - logstash
+    - fluentd
+    - bash
     samm2: o-incident-management|A|1
     iso27001-2017:
     - 12.4.1

--- a/data-new/InformationGathering/Monitoring.yaml
+++ b/data-new/InformationGathering/Monitoring.yaml
@@ -1,7 +1,7 @@
----
 Monitoring:
   Advanced availability and stability metrics:
-    risk: Trends and advanced attacks are not detected.
+    risk:
+    - Trends and advanced attacks are not detected.
     measure: Advanced metrics are gathered in relation to availability and stability.
       For example unplanned downtime's per year.
     difficultyOfImplementation:
@@ -16,8 +16,10 @@ Monitoring:
     samm2: o-incident-management|A|2
     iso27001-2017:
     - 12.1.3
+    implementation: []
   Advanced webapplication metrics:
-    risk: People are not looking into tests results. Vulnerabilities not recolonized,
+    risk:
+    - People are not looking into tests results. Vulnerabilities not recolonized,
       even they are detected by tools.
     measure: All defects from the dimension Test- and Verification are instrumented.
     difficultyOfImplementation:
@@ -32,8 +34,10 @@ Monitoring:
     samm2: o-incident-management|A|2
     iso27001-2017:
     - 12.6.1
+    implementation: []
   Alerting:
-    risk: Incidents are discovered after they happened.
+    risk:
+    - Incidents are discovered after they happened.
     measure: |
       Thresholds for metrics are set. In case the thresholds are reached, alarms are send out. Which should get attention due to the critically.
     difficultyOfImplementation:
@@ -50,15 +54,16 @@ Monitoring:
     - 16.1.2
     - 16.1.4
     - 12.1.4
+    implementation: []
   Coverage and control metrics:
-    risk: The effectiveness of configuration, patch and vulnerability management is
-      unknown.
-    measure: "Usage of Coverage- and control-metrics to show the effectiveness of
-      the security program. Coverage is the degree in \n        which a specific security
-      control for a specific target group is applied with all resources.\n        The
-      control degree shows the actual application of security standards and security-guidelines.
-      Examples are gathering information on anti-virus, anti-rootkits, patch management,
-      server configuration and vulnerability management."
+    risk:
+    - The effectiveness of configuration, patch and vulnerability management is unknown.
+    measure: "Usage of Coverage- and control-metrics to show the effectiveness of\
+      \ the security program. Coverage is the degree in \n        which a specific\
+      \ security control for a specific target group is applied with all resources.\n\
+      \        The control degree shows the actual application of security standards\
+      \ and security-guidelines. Examples are gathering information on anti-virus,\
+      \ anti-rootkits, patch management, server configuration and vulnerability management."
     difficultyOfImplementation:
       knowledge: 3
       time: 5
@@ -67,12 +72,14 @@ Monitoring:
     level: 4
     dependsOn:
     - Visualized metrics
-    implementation: https://ht.transparencytoolkit.org/FileServer/FileServer/OLD%20Fileserver/books/SICUREZZA/Addison.Wesley.Security.Metrics.Mar.2007.pdf
+    implementation:
+    - https://ht.transparencytoolkit.org/FileServer/FileServer/OLD%20Fileserver/books/SICUREZZA/Addison.Wesley.Security.Metrics.Mar.2007.pdf
     samm2: o-incident-management|A|2
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
   Deactivation of unused metrics:
-    risk: High resources are used while gathering unused metrics.
+    risk:
+    - High resources are used while gathering unused metrics.
     measure: Deactivation of unused metrics helps to free resources.
     difficultyOfImplementation:
       knowledge: 2
@@ -86,9 +93,11 @@ Monitoring:
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.1.3
+    implementation: []
   Defense metrics:
-    risk: IDS/IPS systems like packet- or application-firewalls detect and prevent
-      attacks. It is not known how many attacks has been detected and blocked.
+    risk:
+    - IDS/IPS systems like packet- or application-firewalls detect and prevent attacks.
+      It is not known how many attacks has been detected and blocked.
     measure: |
       Gathering of defense metrics like TCP/UDP sources enables to assume the geographic location of the request.
       Assuming a Kubernetes cluster with an egress-traffic filter (e.g. IP/domain based), an alert might be send out in case of every violation. For ingress-traffic, alerting might not even be considered.
@@ -105,8 +114,10 @@ Monitoring:
     iso27001-2017:
     - 12.4.1
     - 13.1.1
+    implementation: []
   Grouping of metrics:
-    risk: The analysis of metrics takes long.
+    risk:
+    - The analysis of metrics takes long.
     measure: Meaningful grouping of metrics helps to speed up analysis.
     difficultyOfImplementation:
       knowledge: 2
@@ -118,8 +129,10 @@ Monitoring:
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 12.1.3
+    implementation: []
   Metrics are combined with tests:
-    risk: Changes might cause high load due to programming errors.
+    risk:
+    - Changes might cause high load due to programming errors.
     measure: Metrics during tests helps to identify programming errors.
     difficultyOfImplementation:
       knowledge: 2
@@ -132,8 +145,10 @@ Monitoring:
     samm2: o-incident-management|A|2
     iso27001-2017:
     - not explicitly covered by ISO 27001
+    implementation: []
   Screens with metric visualization:
-    risk: Security related information is discovered too late during an incident.
+    risk:
+    - Security related information is discovered too late during an incident.
     measure: By having an internal accessible screen with a security related dashboards
       helps to visualize incidents.
     difficultyOfImplementation:
@@ -148,8 +163,10 @@ Monitoring:
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 16.1.5
+    implementation: []
   Simple application metrics:
-    risk: Attacks on an application are not recognized.
+    risk:
+    - Attacks on an application are not recognized.
     measure: Gathering of application metrics helps to identify incidents like brute
       force attacks, login/logout.
     difficultyOfImplementation:
@@ -158,12 +175,14 @@ Monitoring:
       resources: 2
     usefulness: 5
     level: 1
-    implementation: Prometheus
+    implementation:
+    - Prometheus
     samm2: o-incident-management|A|1
     iso27001-2017:
     - 12.4.1
   Simple system metrics:
-    risk: Without simple metrics analysis of incidents are hard. In case an application
+    risk:
+    - Without simple metrics analysis of incidents are hard. In case an application
       uses a lot of CPU from time to time, it is hard for a developer to find out
       the source with Linux commands.
     measure: Gathering of system metrics helps to identify incidents and specially
@@ -174,13 +193,15 @@ Monitoring:
       resources: 2
     usefulness: 5
     level: 1
-    implementation: collected
+    implementation:
+    - collected
     samm2: o-incident-management|A|1
     iso27001-2017:
     - 12.1.3
   Targeted alerting:
-    risk: People are bored (ignorant) of incident alarm messages, as they are not
-      responsible to react.
+    risk:
+    - People are bored (ignorant) of incident alarm messages, as they are not responsible
+      to react.
     measure: By the definition of target groups for incidents people are only getting
       alarms for incidents they are in charge for.
     difficultyOfImplementation:
@@ -196,8 +217,10 @@ Monitoring:
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - 16.1.5
+    implementation: []
   Visualized metrics:
-    risk: Not visualized metrics lead to restricted usage of metrics.
+    risk:
+    - Not visualized metrics lead to restricted usage of metrics.
     measure: Metrics are visualized in real time in a user friendly way.
     difficultyOfImplementation:
       knowledge: 1
@@ -211,4 +234,4 @@ Monitoring:
     samm2: o-incident-management|A|2
     iso27001-2017:
     - 12.1.3
-...
+    implementation: []

--- a/data-new/InformationGathering/_meta.yaml
+++ b/data-new/InformationGathering/_meta.yaml
@@ -1,6 +1,5 @@
----
 _meta:
-  label: "Information Gathering"
-  icon: "Information Gathering.png"
+  label: Information Gathering
+  icon: Information Gathering.png
   description: |-
     A markdown description of this dimension.

--- a/data-new/TestAndVerification/ApplicationTests.yaml
+++ b/data-new/TestAndVerification/ApplicationTests.yaml
@@ -1,8 +1,8 @@
----
 Application tests:
   High coverage of security related module and integration tests:
-    risk: Vulnerabilities are rising due to code changes in a complex microservice
-      environment in not important components.
+    risk:
+    - Vulnerabilities are rising due to code changes in a complex microservice environment
+      in not important components.
     measure: Implementation of security related tests via unit tests and integration
       tests. Including the test of libraries, in case the are not tested already.
     difficultyOfImplementation:
@@ -16,9 +16,10 @@ Application tests:
     iso27001-2017:
     - 14.2.3
     - 14.2.8
+    implementation: []
   Security integration tests for important components:
-    risk: Vulnerabilities are rising due to code changes in a complex microservice
-      environment.
+    risk:
+    - Vulnerabilities are rising due to code changes in a complex microservice environment.
     measure: Implementation of essential security related integration tests. For example
       for authentication and authorization.
     difficultyOfImplementation:
@@ -27,14 +28,16 @@ Application tests:
       resources: 2
     usefulness: 2
     level: 3
-    implementation: HttpUnit
+    implementation:
+    - HttpUnit
     samm: ST2-B
     samm2: v-security-testing|B|3
     iso27001-2017:
     - 14.2.3
     - 14.2.8
   Security unit tests for important components:
-    risk: Vulnerabilities are rising due to code changes.
+    risk:
+    - Vulnerabilities are rising due to code changes.
     measure: Usage of unit tests to test important security related features like
       authentication and authorization.
     difficultyOfImplementation:
@@ -55,8 +58,9 @@ Application tests:
     - 14.2.3
     - 14.2.8
   Smoke Test:
-    risk: During a deployment an error might happen which leads to non-availability
-      of the system, a part of the system or a feature.
+    risk:
+    - During a deployment an error might happen which leads to non-availability of
+      the system, a part of the system or a feature.
     measure: Integration tests are performed against the production environment after
       each deployment.
     difficultyOfImplementation:
@@ -65,7 +69,7 @@ Application tests:
       resources: 2
     usefulness: 2
     level: 4
-    implementation: ""
+    implementation: []
     dependsOn:
     - Defined deployment process
     samm: ST2-B
@@ -73,4 +77,3 @@ Application tests:
     iso27001-2017:
     - 14.2.3
     - 14.2.8
-...

--- a/data-new/TestAndVerification/Consolidation.yaml
+++ b/data-new/TestAndVerification/Consolidation.yaml
@@ -1,8 +1,8 @@
----
 Consolidation:
   Advanced visualization of defects:
-    risk: Correlation of the vulnerabilities of different tools to have an overview
-      of the the overall security level per component/project/team is not given.
+    risk:
+    - Correlation of the vulnerabilities of different tools to have an overview of
+      the the overall security level per component/project/team is not given.
     measure: Findings are visualized per component/project/team.
     difficultyOfImplementation:
       knowledge: 2
@@ -20,7 +20,8 @@ Consolidation:
     - 8.2.2
     - 8.2.3
   Definition of quality gates:
-    risk: Improper examination of vulnerabilities leads to no visibility at all.
+    risk:
+    - Improper examination of vulnerabilities leads to no visibility at all.
     measure: Quality gates for found vulnerabilities are defined. In the start it
       is important to not overload the security analyst, therefore the recommendation
       is to start with alerting of high critical vulnerabilities.
@@ -36,11 +37,14 @@ Consolidation:
     - not explicitly covered by ISO 27001 - too specific
     - 12.6.1
     - 16.1.4
-    implementation: See other actions, e.g. "Treatment of defects with severity high".
+    implementation:
+    - See other actions
+    - ' e.g. "Treatment of defects with severity high".'
   Integration of vulnerability issues into the development process:
-    risk: To read console output of the build server to search for vulnerabilities
-      might be difficult. Also, to check a vulnerability management system might not
-      be a daily task for a developer.
+    risk:
+    - To read console output of the build server to search for vulnerabilities might
+      be difficult. Also, to check a vulnerability management system might not be
+      a daily task for a developer.
     measure: Vulnerabilities are tracked in the teams issue system (e.g. jira).
     difficultyOfImplementation:
       knowledge: 2
@@ -48,10 +52,11 @@ Consolidation:
       resources: 1
     usefulness: 2
     level: 3
-    implementation: 'At SAST (Static Application Security Testing): Server-side /
-      client-side teams can easily be recorded. With microservice architecture, individual
-      microservices can be used usually Teams. At DAST (Dynamic Application Security
-      Testing): vulnerabilities are classified and can be assigned to server-side
+    implementation:
+    - 'At SAST (Static Application Security Testing): Server-side / client-side teams
+      can easily be recorded. With microservice architecture'
+    - ' individual microservices can be used usually Teams. At DAST (Dynamic Application
+      Security Testing): vulnerabilities are classified and can be assigned to server-side
       and client-side teams.'
     samm2: i-defect-management|B|2
     iso27001-2017:
@@ -60,8 +65,9 @@ Consolidation:
     - 16.1.5
     - 16.1.6
   Reproducible defect tickets:
-    risk: Vulnerability descriptions are hard to understand by staff from operations
-      and development.
+    risk:
+    - Vulnerability descriptions are hard to understand by staff from operations and
+      development.
     measure: Vulnerabilities include the test procedure to give the staff from operations
       and development the ability to reproduce vulnerabilities. This enhances the
       understanding of vulnerabilities and therefore the fix have a higher quality.
@@ -71,7 +77,8 @@ Consolidation:
       resources: 2
     usefulness: 2
     level: 4
-    implementation: <a href='https://github.com/mozilla/zest'>Mozilla Zest</a>
+    implementation:
+    - <a href='https://github.com/mozilla/zest'>Mozilla Zest</a>
     samm2: i-defect-management|B|2
     iso27001-2017:
     - 16.1.4
@@ -79,8 +86,8 @@ Consolidation:
     - 8.2.2
     - 8.2.3
   Simple false positive treatment:
-    risk: As false positive occur during each test, all vulnerabilities might be
-      ignored.
+    risk:
+    - As false positive occur during each test, all vulnerabilities might be ignored.
     measure: False positives are suppressed so they will not show up on the next tests
       again. Most security tools have the possibility to suppress false positives.
       A Vulnerability Management System might be used.
@@ -99,7 +106,8 @@ Consolidation:
     - not explicitly covered by ISO 27001 - too specific
     - 16.1.6
   Simple visualization of defects:
-    risk: The security level of a component is not visible. Therefore, the motivation
+    risk:
+    - The security level of a component is not visible. Therefore, the motivation
       to enhance the security is not give.
     measure: Vulnerabilities are simple visualized.
     difficultyOfImplementation:
@@ -120,7 +128,8 @@ Consolidation:
     - 8.2.2
     - 8.2.3
   Treatment of all defects:
-    risk: Vulnerabilities with severity low are not visible.
+    risk:
+    - Vulnerabilities with severity low are not visible.
     measure: All vulnerabilities are added to the quality gate.
     difficultyOfImplementation:
       knowledge: 3
@@ -132,8 +141,10 @@ Consolidation:
     iso27001-2017:
     - 16.1.4
     - 12.6.1
+    implementation: []
   Treatment of defects with severity high or higher:
-    risk: Vulnerabilities with severity high or higher are not visible.
+    risk:
+    - Vulnerabilities with severity high or higher are not visible.
     measure: Vulnerabilities with severity high or higher are added to the quality
       gate.
     difficultyOfImplementation:
@@ -147,8 +158,10 @@ Consolidation:
     iso27001-2017:
     - 16.1.4
     - 12.6.1
+    implementation: []
   Treatment of defects with severity middle:
-    risk: Vulnerabilities with severity middle are not visible.
+    risk:
+    - Vulnerabilities with severity middle are not visible.
     measure: Vulnerabilities with severity middle are added to the quality gate.
     difficultyOfImplementation:
       knowledge: 2
@@ -161,9 +174,11 @@ Consolidation:
     iso27001-2017:
     - 16.1.4
     - 12.6.1
+    implementation: []
   Usage of a vulnerability management system:
-    risk: Maintenance of false positives in each tool enforces a high workload. In
-      addition a correlation of the same finding from different tools is not possible.
+    risk:
+    - Maintenance of false positives in each tool enforces a high workload. In addition
+      a correlation of the same finding from different tools is not possible.
     measure: Aggregation of vulnerabilities in one tool reduce the workload to mark
       false positives.
     difficultyOfImplementation:
@@ -182,4 +197,3 @@ Consolidation:
     - 16.1.4
     - 16.1.5
     - 16.1.6
-...

--- a/data-new/TestAndVerification/DynamicDepthForApplications.yaml
+++ b/data-new/TestAndVerification/DynamicDepthForApplications.yaml
@@ -1,7 +1,7 @@
----
 Dynamic depth for applications:
   Coverage analysis:
-    risk: Parts of the service are not still covered.
+    risk:
+    - Parts of the service are not still covered.
     measure: Check that there are no missing paths in the application with coverage-tools.
     difficultyOfImplementation:
       knowledge: 4
@@ -9,14 +9,16 @@ Dynamic depth for applications:
       resources: 3
     usefulness: 4
     level: 4
-    implementation: OWASP Code Pulse
+    implementation:
+    - OWASP Code Pulse
     samm2: v-security-testing|A|2
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
     - part of periodic review, PDCA
   Coverage of client side dynamic components:
-    risk: Parts of the service are not covered during the scan, because JavaScript
-      is not getting executed. Therefore, the co
+    risk:
+    - Parts of the service are not covered during the scan, because JavaScript is
+      not getting executed. Therefore, the co
     measure: Usage of a spider which executes dynamic content like JavaScript, e.g.
       via Selenium.
     difficultyOfImplementation:
@@ -32,9 +34,11 @@ Dynamic depth for applications:
     iso27001-2017:
     - 14.2.3
     - 14.2.8
-    implementation: Ajax Spider
+    implementation:
+    - Ajax Spider
   Coverage of hidden endpoints:
-    risk: Hidden endpoints of the service are not getting tracked.
+    risk:
+    - Hidden endpoints of the service are not getting tracked.
     measure: Hidden endpoints are getting detected and included in the vulnerability
       scan.
     difficultyOfImplementation:
@@ -43,15 +47,18 @@ Dynamic depth for applications:
       resources: 1
     usefulness: 5
     level: 3
-    implementation: cURL, OpenAPI
+    implementation:
+    - cURL
+    - ' OpenAPI'
     dependsOn:
     - Usage of different roles
     samm2: v-security-testing|A|2
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
   Coverage of more input vectors:
-    risk: Parts of the service are not covered. For example specially formatted or
-      coded parameters are not getting detected as parameter (e.g. parameters in REST-like
+    risk:
+    - Parts of the service are not covered. For example specially formatted or coded
+      parameters are not getting detected as parameter (e.g. parameters in REST-like
       URLs, parameters in JSON-Format or base64-coded parameters).
     measure: Special parameter and special encodings are defined, so that they get
       fuzzed by the used vulnerability scanners.
@@ -66,9 +73,10 @@ Dynamic depth for applications:
     samm2: v-security-testing|A|2
     iso27001-2017:
     - not explicitly covered by ISO 27001 - too specific
+    implementation: []
   Coverage of sequential operations:
-    risk: Sequential operations like workflows (e.g. login -> put products in the
-      basket
+    risk:
+    - Sequential operations like workflows (e.g. login -> put products in the basket
     measure: Sequential operations are defined and checked by the vulnerability scanner
       in the defined order.
     difficultyOfImplementation:
@@ -77,7 +85,8 @@ Dynamic depth for applications:
       resources: 1
     usefulness: 5
     level: 3
-    implementation: cURL
+    implementation:
+    - cURL
     dependsOn:
     - Usage of different roles
     samm2: v-security-testing|A|2
@@ -85,7 +94,8 @@ Dynamic depth for applications:
     - 14.2.8
     - 14.2.3
   Coverage of service to service communication:
-    risk: Service to service communication is not covered.
+    risk:
+    - Service to service communication is not covered.
     measure: Service to service communication is dumped and checked.
     difficultyOfImplementation:
       knowledge: 4
@@ -99,8 +109,10 @@ Dynamic depth for applications:
     iso27001-2017:
     - 14.2.3
     - 14.2.8
+    implementation: []
   Simple Scan:
-    risk: Deficient security tests are performed. Simple vulnerabilities are not detected
+    risk:
+    - Deficient security tests are performed. Simple vulnerabilities are not detected
       and missing security configurations (e.g. headers) are not set. Fast feedback
       is not given.
     measure: A simple scan is performed to get a security baseline. In case the test
@@ -122,8 +134,9 @@ Dynamic depth for applications:
     - 14.2.3
     - 14.2.8
   Usage of different roles:
-    risk: Parts of the service are not covered during the scan, because a login is
-      not performed.
+    risk:
+    - Parts of the service are not covered during the scan, because a login is not
+      performed.
     measure: Integration of authentication with all roles used in the service.
     difficultyOfImplementation:
       knowledge: 3
@@ -138,9 +151,11 @@ Dynamic depth for applications:
     - not explicitly covered by ISO 27001 - too specific
     - 14.2.3
     - 14.2.8
+    implementation: []
   Usage of multiple scanners:
-    risk: Each vulnerability scanner has different opportunities. By using just one
-      scanner, some vulnerabilities might not be found.
+    risk:
+    - Each vulnerability scanner has different opportunities. By using just one scanner,
+      some vulnerabilities might not be found.
     measure: Usage of multiple spiders and scanner enhance the coverage and the vulnerabilities.
     difficultyOfImplementation:
       knowledge: 3
@@ -150,9 +165,9 @@ Dynamic depth for applications:
     level: 3
     dependsOn:
     - Usage of different roles
-    implementation: SecureCodeBox
+    implementation:
+    - SecureCodeBox
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 12.6.1
     - 14.2.5
-...

--- a/data-new/TestAndVerification/DynamicDepthForInfrastructure.yaml
+++ b/data-new/TestAndVerification/DynamicDepthForInfrastructure.yaml
@@ -1,8 +1,8 @@
----
 Dynamic depth for infrastructure:
   Load tests:
-    risk: As it is unknown how many requests the systems and applications can serve,
-      due to an unexpected load the availability is disturbed.
+    risk:
+    - As it is unknown how many requests the systems and applications can serve, due
+      to an unexpected load the availability is disturbed.
     measure: Load test against the production system or a production near system is
       performed.
     difficultyOfImplementation:
@@ -16,8 +16,10 @@ Dynamic depth for infrastructure:
     - 12.1.3
     - 14.2.3
     - 14.2.8
+    implementation: []
   Test of the configuration of cloud environments:
-    risk: Standard hardening practices for cloud environments are not performed leading
+    risk:
+    - Standard hardening practices for cloud environments are not performed leading
       to vulnerabilities.
     measure: With the help of tools the configuration of virtual environments are
       tested.
@@ -37,8 +39,9 @@ Dynamic depth for infrastructure:
     - 14.2.3
     - 14.2.8
   Weak password test:
-    risk: Weak passwords in components like applications or systems, specially for
-      privileged accounts, lead to take over of that account.
+    risk:
+    - Weak passwords in components like applications or systems, specially for privileged
+      accounts, lead to take over of that account.
     measure: Automatic brute force attacks are performed. Specially the usage of standard
       accounts like 'admin' and employee user-ids is recommended.
     difficultyOfImplementation:
@@ -47,13 +50,15 @@ Dynamic depth for infrastructure:
       resources: 1
     usefulness: 1
     level: 3
-    implementation: HTC Hydra
+    implementation:
+    - HTC Hydra
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 9.4.3
   Test network segmentation:
-    risk: Wrong or no network segmentation of pods makes it easier for an attacker
-      to access a database and extract or modify data.
+    risk:
+    - Wrong or no network segmentation of pods makes it easier for an attacker to
+      access a database and extract or modify data.
     measure: Cluster internal test needs to be performed. Integration of fine granulated
       network segmentation (also between pods in the same namespace).
     difficultyOfImplementation:
@@ -62,7 +67,8 @@ Dynamic depth for infrastructure:
       resources: 1
     usefulness: 3
     level: 2
-    implementation: <a href="https://github.com/controlplaneio/netassert">netassert</a>
+    implementation:
+    - <a href="https://github.com/controlplaneio/netassert">netassert</a>
     dependsOn: Segmented networks for virtual environments
     samm2: v-security-testing|A|2
     iso27001-2017:
@@ -70,7 +76,8 @@ Dynamic depth for infrastructure:
     - 14.2.3
     - 14.2.8
   Test for exposed services:
-    risk: Standard network segmentation and firewalling has not been performed, leading
+    risk:
+    - Standard network segmentation and firewalling has not been performed, leading
       to world open cluster management ports.
     measure: With the help of tools the network configuration of unintentional exposed
       cluster(s) are tested. To identify clusters, all subdomains might need to be
@@ -90,4 +97,3 @@ Dynamic depth for infrastructure:
     - 13.1.3
     - 14.2.3
     - 14.2.8
-...

--- a/data-new/TestAndVerification/StaticDepthForApplications.yaml
+++ b/data-new/TestAndVerification/StaticDepthForApplications.yaml
@@ -1,7 +1,7 @@
----
 Static depth for applications:
   Exclusion of source code duplicates:
-    risk: Duplicates in source code might influence the stability of the application.
+    risk:
+    - Duplicates in source code might influence the stability of the application.
     measure: Automatic Detection and manual removal of duplicates in source code.
     difficultyOfImplementation:
       knowledge: 1
@@ -9,7 +9,8 @@ Static depth for applications:
       resources: 1
     usefulness: 1
     level: 4
-    implementation: PMD
+    implementation:
+    - PMD
     dependsOn:
     - Defined build process
     samm2: v-security-testing|A|2
@@ -18,7 +19,8 @@ Static depth for applications:
     - 14.2.1
     - 14.2.5
   Static analysis for all components/libraries:
-    risk: Used components like libraries and legacy applications might have vulnerabilities
+    risk:
+    - Used components like libraries and legacy applications might have vulnerabilities
     measure: Usage of a static analysis for all used components.
     difficultyOfImplementation:
       knowledge: 2
@@ -32,8 +34,10 @@ Static depth for applications:
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 12.6.1
+    implementation: []
   Static analysis for all self written components:
-    risk: Parts in the source code of the frontend or middleware have vulnerabilities.
+    risk:
+    - Parts in the source code of the frontend or middleware have vulnerabilities.
     measure: Usage of static analysis tools for all parts of the middleware and frontend.
       Static analysis uses for example string matching algorithms and/or dataflow
       analysis.
@@ -43,7 +47,10 @@ Static depth for applications:
       resources: 1
     usefulness: 4
     level: 4
-    implementation: eslint, FindSecurityBugs, jsprime
+    implementation:
+    - eslint
+    - ' FindSecurityBugs'
+    - ' jsprime'
     dependsOn:
     - Static analysis for important client side components
     - Static analysis for important server side components
@@ -51,7 +58,8 @@ Static depth for applications:
     iso27001-2017:
     - 12.6.1
   Static analysis for important client side components:
-    risk: Important parts in the source code of the frontend have vulnerabilities.
+    risk:
+    - Important parts in the source code of the frontend have vulnerabilities.
     measure: Usage of static analysis tools for important parts of the frontend are
       used. Static analysis uses for example string matching algorithms and/or dataflow
       analysis.
@@ -72,7 +80,8 @@ Static depth for applications:
     dependsOn:
     - Defined build process
   Static analysis for important server side components:
-    risk: Important parts in the source code of the middleware have vulnerabilities.
+    risk:
+    - Important parts in the source code of the middleware have vulnerabilities.
     measure: Usage of static analysis tools for important parts of the middleware
       are used. Static analysis uses for example string matching algorithms and/or
       dataflow analysis.
@@ -82,14 +91,18 @@ Static depth for applications:
       resources: 1
     usefulness: 4
     level: 2
-    implementation: eslint, FindSecurityBugs, jsprime
+    implementation:
+    - eslint
+    - ' FindSecurityBugs'
+    - ' jsprime'
     dependsOn:
     - Defined build process
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 12.6.1
   Stylistic analysis:
-    risk: False source code indenting might lead to vulnerabilities.
+    risk:
+    - False source code indenting might lead to vulnerabilities.
     measure: Analysis of compliance to style guides of the source code ensures that
       source code indenting rules are met.
     difficultyOfImplementation:
@@ -98,14 +111,16 @@ Static depth for applications:
       resources: 1
     usefulness: 1
     level: 4
-    implementation: PMD
+    implementation:
+    - PMD
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 12.6.1
     - 14.2.1
     - 14.2.5
   Test of client side components with known vulnerabilities:
-    risk: Client side components might have vulnerabilities.
+    risk:
+    - Client side components might have vulnerabilities.
     measure: Tests for known vulnerabilities in components of the frontend are performed.
     difficultyOfImplementation:
       knowledge: 1
@@ -122,7 +137,8 @@ Static depth for applications:
     iso27001-2017:
     - 12.6.1
   Test of server side components with known vulnerabilities:
-    risk: Server side components might have vulnerabilities.
+    risk:
+    - Server side components might have vulnerabilities.
     measure: Tests for known vulnerabilities in server side components (e.g. backend/middleware)
       are performed.
     difficultyOfImplementation:
@@ -133,14 +149,16 @@ Static depth for applications:
     level: 1
     dependsOn:
     - Defined build process
-    implementation: OWASP Dependency Check
+    implementation:
+    - OWASP Dependency Check
     samm: SA
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 12.6.1
   Usage of multiple analyzers:
-    risk: Each vulnerability analyzer has different opportunities. By using just one
-      analyzer, some vulnerabilities might not be found.
+    risk:
+    - Each vulnerability analyzer has different opportunities. By using just one analyzer,
+      some vulnerabilities might not be found.
     measure: Usage of multiple static tools to find more vulnerabilities.
     difficultyOfImplementation:
       knowledge: 3
@@ -157,4 +175,4 @@ Static depth for applications:
     - Test of server side components with known vulnerabilities
     - Test of client side components with known vulnerabilities
     - Static analysis for all self written components
-...
+    implementation: []

--- a/data-new/TestAndVerification/StaticDepthForInfrastructure.yaml
+++ b/data-new/TestAndVerification/StaticDepthForInfrastructure.yaml
@@ -1,7 +1,7 @@
----
 Static depth for infrastructure:
   Analyze logs:
-    risk: Not getting are of happened attacks.
+    risk:
+    - Not getting are of happened attacks.
     measure: Check logs for keywords.
     difficultyOfImplementation:
       knowledge: 2
@@ -12,8 +12,9 @@ Static depth for infrastructure:
     implementation:
     - https://github.com/Neo23x0/sigma
   Test of virtualized environments:
-    risk: Virtualized environments (e.g. via <i>Container Images</i>) might contains
-      unsecure configurations.
+    risk:
+    - Virtualized environments (e.g. via <i>Container Images</i>) might contains unsecure
+      configurations.
     measure: Test virtualized environments for unsecured configurations.
     difficultyOfImplementation:
       knowledge: 2
@@ -26,8 +27,9 @@ Static depth for infrastructure:
     - Cluster Scanner (will be open sourced soon) to check different aspects
     samm2: v-security-testing|A|1
   Test the definition of virtualized environments:
-    risk: The definition of virtualized environments (e.g. via <i>Dockerfile</i>)
-      might contains unsecure configurations.
+    risk:
+    - The definition of virtualized environments (e.g. via <i>Dockerfile</i>) might
+      contains unsecure configurations.
     measure: Test the definition of virtualized environments for unsecured configurations.
     difficultyOfImplementation:
       knowledge: 2
@@ -47,8 +49,9 @@ Static depth for infrastructure:
     - 14.2.8
     - 14.2.1
   Test cluster deployment resources:
-    risk: The deployment configuration (e.g. kubernetes deployment resources) might
-      contain unsecured configurations.
+    risk:
+    - The deployment configuration (e.g. kubernetes deployment resources) might contain
+      unsecured configurations.
     measure: Test the deployment configuration for virtualized environments for unsecured
       configurations.
     difficultyOfImplementation:
@@ -66,7 +69,8 @@ Static depth for infrastructure:
     - 14.2.3
     - 14.2.8
   Test of infrastructure components for known vulnerabilities:
-    risk: Infrastructure components might have vulnerabilities.
+    risk:
+    - Infrastructure components might have vulnerabilities.
     measure: Test for known vulnerabilities in infrastructure components. Often, the
       only way to respond to known vulnerabilities in operating system packages is
       to accept the risk and wait for a patch. As the patch needs to be applied fast
@@ -90,7 +94,8 @@ Static depth for infrastructure:
     - 12.6.1
     - 14.2.1
   Correlate known vulnerabilities in infrastructure with new image versions:
-    risk: TODO.
+    risk:
+    - TODO.
     measure: TODO
     difficultyOfImplementation:
       knowledge: 2
@@ -110,7 +115,8 @@ Static depth for infrastructure:
     - 12.6.1
     - 14.2.1
   Test the cloud configuration:
-    risk: Standard hardening practices for cloud environments are not performed leading
+    risk:
+    - Standard hardening practices for cloud environments are not performed leading
       to vulnerabilities.
     measure: With the help of tools the configuration of virtual environments are
       tested.
@@ -130,7 +136,8 @@ Static depth for infrastructure:
     - 14.2.3
     - 14.2.8
   Stored Secrets:
-    risk: Stored secrets in git history, in container images or directly in code shouldn't
+    risk:
+    - Stored secrets in git history, in container images or directly in code shouldn't
       exists because they might be read unauthorized.
     measure: Test for secrets in code, container images and history
     difficultyOfImplementation:
@@ -148,8 +155,9 @@ Static depth for infrastructure:
     - 9.4.3
     - 10.1.2
   Check for image lifetime:
-    risk: Old container images in production indicate that patch management is not
-      performed and therefore vulnerabilities might exists.
+    risk:
+    - Old container images in production indicate that patch management is not performed
+      and therefore vulnerabilities might exists.
     measure: Check the image age of containers in production.
     difficultyOfImplementation:
       knowledge: 2
@@ -157,14 +165,15 @@ Static depth for infrastructure:
       resources: 1
     usefulness: 2
     level: 3
-    implementation: ~
+    implementation: []
     samm2: v-security-testing|A|1
     iso27001-2017:
     - 12.6.1
     - 14.2.5
   Check for known vulnerabilities:
-    risk: Known vulnerabilities in infrastructure components like container images
-      might get exploited.
+    risk:
+    - Known vulnerabilities in infrastructure components like container images might
+      get exploited.
     measure: Check for known vulnerabilities
     difficultyOfImplementation:
       knowledge: 2
@@ -180,7 +189,8 @@ Static depth for infrastructure:
     iso27001-2017:
     - 12.6.1
   Check for new image version:
-    risk: When a new version of an image is available, it might fixes security vulnerabilities.
+    risk:
+    - When a new version of an image is available, it might fixes security vulnerabilities.
     measure: Check for new images of containers in production.
     difficultyOfImplementation:
       knowledge: 3
@@ -188,16 +198,17 @@ Static depth for infrastructure:
       resources: 1
     usefulness: 2
     level: 3
-    implementation: ~
+    implementation: []
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 12.6.1
     - 14.2.5
     - 12.2.1
   Check for malware:
-    risk: Third party might include  malware. Ether due to the maintainer (e.g. typo
-      squatting of an image name and using the wrong image) or by an attacker on behalf
-      of the maintainer with stolen credentials.
+    risk:
+    - Third party might include  malware. Ether due to the maintainer (e.g. typo squatting
+      of an image name and using the wrong image) or by an attacker on behalf of the
+      maintainer with stolen credentials.
     measure: Check for malware in components (e.g. container images, VM baseline images,
       libraries).
     difficultyOfImplementation:
@@ -206,8 +217,7 @@ Static depth for infrastructure:
       resources: 2
     usefulness: 3
     level: 3
-    implementation: ~
+    implementation: []
     samm2: v-security-testing|A|2
     iso27001-2017:
     - 12.2.1
-...

--- a/data-new/TestAndVerification/Test-Intensity.yaml
+++ b/data-new/TestAndVerification/Test-Intensity.yaml
@@ -1,7 +1,7 @@
----
 Test-Intensity:
   Regular tests:
-    risk: After pushing source code to the version control system, any delay in receiving
+    risk:
+    - After pushing source code to the version control system, any delay in receiving
       feedback on defects makes them harder for the developer to remediate.
     measure: On each push and/or at given intervals automatic security tests are performed.
     difficultyOfImplementation:
@@ -10,14 +10,15 @@ Test-Intensity:
       resources: 1
     usefulness: 2
     level: 2
-    implementation: ""
+    implementation: []
     samm2: i-secure-build|A|3
     iso27001-2017:
     - 14.2.3
     - 14.2.8
     - 14.2.9
   Creation and application of a testing concept:
-    risk: Scans might use a too small or too high test intensity.
+    risk:
+    - Scans might use a too small or too high test intensity.
     measure: A testing concept considering the amount of time per scan/intensity is
       created and applied. A dynamic analysis needs more time than a static analysis.
       The dynamic scan, depending on the test intensity might be performed on every
@@ -35,10 +36,12 @@ Test-Intensity:
     - 14.2.1
     - 14.2.5
     - 12.6.1
+    implementation: []
   Deactivating of unneeded tests:
-    risk: As tools cover a wide range of different vulnerability tests, they might
-      not match the used components. Therefore, they need more time and resources
-      as they need and the feedback loops takes too much time.
+    risk:
+    - As tools cover a wide range of different vulnerability tests, they might not
+      match the used components. Therefore, they need more time and resources as they
+      need and the feedback loops takes too much time.
     measure: Unneeded tests are deactivated. For example in case the service is using
       a Mongo database and no mysql database, the dynamic scan doesn't need to test
       for sql injections.
@@ -53,9 +56,10 @@ Test-Intensity:
     - 12.6.1
     - 14.2.1
     - 14.2.5
+    implementation: []
   Default settings for intensity:
-    risk: Time pressure and ignorance might lead to false predictions for the test
-      intensity.
+    risk:
+    - Time pressure and ignorance might lead to false predictions for the test intensity.
     measure: The intensity of the used tools are not modified to safe time.
     difficultyOfImplementation:
       knowledge: 1
@@ -68,9 +72,10 @@ Test-Intensity:
     - 12.6.1
     - 14.2.1
     - 14.2.5
+    implementation: []
   High test intensity:
-    risk: A too small intensity or a too high confidence might lead to not visible
-      vulnerabilities.
+    risk:
+    - A too small intensity or a too high confidence might lead to not visible vulnerabilities.
     measure: A deep scan with high test intensity and a low confidence threshold is
       performed.
     difficultyOfImplementation:
@@ -84,4 +89,4 @@ Test-Intensity:
     - 12.6.1
     - 14.2.1
     - 14.2.5
-...
+    implementation: []

--- a/data-new/TestAndVerification/_meta.yaml
+++ b/data-new/TestAndVerification/_meta.yaml
@@ -1,6 +1,5 @@
----
 _meta:
-  label: "Test and Verification"
-  icon: "Test and Verification.png"
+  label: Test and Verification
+  icon: Test and Verification.png
   description: |-
     A markdown description of this dimension.

--- a/scripts/update_schema.py
+++ b/scripts/update_schema.py
@@ -1,3 +1,4 @@
+# This script is used for temporary schema changes and will not last long
 import sys
 from pathlib import Path
 

--- a/scripts/update_schema.py
+++ b/scripts/update_schema.py
@@ -1,0 +1,96 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+from yaml import safe_dump, safe_load
+
+
+def as_list(risk):
+    if isinstance(risk, str):
+        return [risk]
+    return risk
+
+
+def format_references(fpath="data/dimensions.yaml"):
+    # Use the ruamel.yaml to preserve anchors.
+    import ruamel.yaml
+
+    y = ruamel.yaml.YAML(typ="rt")
+
+    dimensions = y.load(Path(fpath).read_text())
+
+    # for dimension, v in dimensions.items():
+    #     if dimension.startswith("_"): continue
+    for subdimension, activity_d in dimensions.items():
+        if subdimension.startswith("_"):
+            continue
+        for activity, data in activity_d.items():
+            if "risk" in data:
+                if isinstance(data["risk"], str):
+                    data["risk"] = [data["risk"]]
+            if v := data.get("implementation"):
+                if isinstance(v, str):
+                    data["implementation"] = v.split(",")
+            else:
+                data["implementation"] = []
+
+            continue
+            if "references" not in data:  # Old model
+                references = []
+                for refid in ("samm", "samm2", "iso27001-2017"):
+                    for s in as_list(data.get(refid, [])):
+                        references.append(f"{refid}:{s}")
+                    if refid in data:
+                        del data[refid]
+                data["references"] = references
+            elif not isinstance(data["references"], list):  # intermediate model with dict refs.
+                references = []
+                for refid in ("samm", "samm2", "iso27001-2017"):
+                    for s in as_list(data["references"].get(refid, [])):
+                        references.append(f"{refid}:{s}")
+                data["references"] = references
+    y.dump(dimensions, stream=Path(fpath))
+    return dimensions
+
+
+def test_format():
+    format_references("data-new/BuildAndDeployment/Sub-Dimensions.yaml")
+
+
+if __name__ == "__main__":
+    format_references(sys.argv[1])
+
+if __name__ == "main__":
+
+    columns = [
+        "dimension",
+        "subdimension",
+        "activity",
+        "risk",
+        # "implementation"
+        "references",
+    ]
+    dimensions = format_references()
+    Path("/tmp/dim.yaml").write_text(safe_dump(dimensions, indent=2))
+
+    activities = [
+        (
+            dimension,
+            subdimension,
+            activity,
+            risk,
+            # implementation
+            references,
+        )
+        for dimension, v in dimensions.items()
+        if not dimension.startswith("_")
+        for subdimension, activity_d in v.items()
+        if not subdimension.startswith("_")
+        for activity, data in activity_d.items()
+        if not activity.startswith("_")
+        for risk in as_list(data.get("risk", []))
+        #  for implementation in as_list(data.get("implementation", [])) or []
+        for references in as_list(data.get("references", [])) or []
+    ]
+    df = pd.DataFrame(activities, columns=columns)
+    df.to_csv("references.csv")


### PR DESCRIPTION
## This PR

- enforces `risk` and `implementation` as lists

## It is done

- using the provided python script
- the script is provided as a tool for validating the refactor
  but it can be removed if you think.

## Notes

The PHP application should already support `risk` and `implementation` as lists