### PR TITLE
Fix: #73. Use reference from SAMM repo.

### DIFF
--- a/data/dimensions-subdimensions-activties/BuildAndDeployment/Sub-Dimensions.yaml
+++ b/data/dimensions-subdimensions-activties/BuildAndDeployment/Sub-Dimensions.yaml
@@ -36,7 +36,7 @@ Build and Deployment:
         tags: []
       references:
         samm2:
-        - i-secure-build|A|2
+        - I-SB-2-A
         iso27001-2017:
         - iso27001-2017:14.2.6
     Defined build process:
@@ -60,7 +60,7 @@ Build and Deployment:
         tags: []
       references:
         samm2:
-        - i-secure-build|A|1
+        - I-SB-1-A
         iso27001-2017:
         - 12.1.1
         - 14.2.2
@@ -79,7 +79,7 @@ Build and Deployment:
       dependsOn:
       - Defined build process
       references:
-        samm2: i-secure-build|A|2
+        samm2: I-SB-2-A
         iso27001-2017:
         - 14.2.6
     Signing of artifacts:
@@ -105,7 +105,7 @@ Build and Deployment:
       - Defined build process
       references:
         samm2:
-        - i-secure-build|A|1
+        - I-SB-1-A
         iso27001-2017:
         - 14.2.6
   Deployment:
@@ -179,7 +179,7 @@ Build and Deployment:
       - name: Docker
         tags: []
       references:
-        samm2: i-secure-deployment|A|1
+        samm2: I-SD-1-A
         iso27001-2017:
         - 12.1.1
         - 14.2.2
@@ -202,7 +202,7 @@ Build and Deployment:
       implementation: []
       references:
         samm2:
-        - i-secure-deployment|B|1
+        - I-SD-1-B
         iso27001-2017:
         - 9.4.5
         - 14.2.6
@@ -225,7 +225,7 @@ Build and Deployment:
         tags: []
       dependsOn:
       - Defined deployment process
-      samm2: i-secure-deployment|A|1
+      samm2: I-SD-1-A
       iso27001-2017:
       - 12.5.1
       - 14.2.2
@@ -247,7 +247,7 @@ Build and Deployment:
         tags: []
       dependsOn:
       - Defined build process
-      samm2: i-secure-deployment|A|2
+      samm2: I-SD-2-A
       iso27001-2017:
       - 14.3.1
       - 14.2.8
@@ -272,7 +272,7 @@ Build and Deployment:
       dependsOn:
         - Environment depending configuration parameters (secrets)
       references:
-        samm2: i-secure-deployment|B|2
+        samm2: I-SD-2-B
         iso27001-2017:
           - 14.1.3
           - 13.1.3
@@ -318,7 +318,7 @@ Build and Deployment:
         resources: 1
       usefulness: 3
       level: 2
-      samm2: i-secure-deployment|A|2
+      samm2: I-SD-2-A
       iso27001-2017:
       - 15.1.1
       - 15.1.2
@@ -356,7 +356,7 @@ Build and Deployment:
         resources: 2
       usefulness: 4
       level: 1
-      samm2: o-environment-management|B|1
+      samm2: O-EM-1-B
       iso27001-2017:
       - 12.6.1
       - 12.5.1
@@ -372,7 +372,7 @@ Build and Deployment:
         resources: 2
       usefulness: 3
       level: 2
-      samm2: o-environment-management|B|1
+      samm2: O-EM-1-B
       iso27001-2017:
       - 12.6.1
       implementation: []
@@ -390,7 +390,7 @@ Build and Deployment:
         resources: 2
       usefulness: 5
       level: 1
-      samm2: o-environment-management|B|1
+      samm2: O-EM-1-B
       iso27001-2017:
       - 12.6.1
       - 14.2.5
@@ -415,7 +415,7 @@ Build and Deployment:
         resources: 2
       usefulness: 3
       level: 2
-      samm2: o-environment-management|B|1
+      samm2: O-EM-1-B
       iso27001-2017:
       - 12.6.1
       implementation: []
@@ -430,7 +430,7 @@ Build and Deployment:
         resources: 2
       usefulness: 3
       level: 4
-      samm2: o-environment-management|B|1
+      samm2: O-EM-1-B
       iso27001-2017:
       - 12.6.1
       implementation:
@@ -459,7 +459,7 @@ Build and Deployment:
         resources: 2
       usefulness: 3
       level: 2
-      samm2: o-environment-management|B|1
+      samm2: O-EM-1-B
       iso27001-2017:
       - hardening is missing in ISO 27001
       - 14.2.1

--- a/data/dimensions-subdimensions-activties/CultureAndOrganization/Design.yaml
+++ b/data/dimensions-subdimensions-activties/CultureAndOrganization/Design.yaml
@@ -11,7 +11,7 @@ Culture and Organization:
       usefulness: 3
       level: 3
       md-description: |
-      samm2: threat-assessment|B|3
+      samm2: D-TA-3-B
       iso27001-2017:
         - not explicitly covered by ISO 27001
         - may be part of risk assessment
@@ -53,7 +53,7 @@ Culture and Organization:
         * Input is escaped output is encoded appropriately using well established libraries.
 
         Source: OWASP Project Integration Project
-      samm2: threat-assessment|B|2
+      samm2: D-TA-2-B
       iso27001-2017:
       - not explicitly covered by ISO 27001
       - may be part of risk assessment
@@ -90,7 +90,7 @@ Culture and Organization:
         resources: 1
       usefulness: 3
       level: 3
-      samm2: threat-assessment|B|2
+      samm2: D-TA-2-B
       iso27001-2017:
       - not explicitly covered by ISO 27001
       - may be part of risk assessment
@@ -168,7 +168,7 @@ Culture and Organization:
           GraphQL queries are dynamically translated to SQL, Elasticsearch and NoSQL queries. Access to data is protected with basic auth set to _1234:1234_ for development purposes.
 
           Source: OWASP Project Integration Project
-      samm2: threat-assessment|B|2
+      samm2: D-TA-2-B
       iso27001-2017:
       - not explicitly covered by ISO 27001
       - may be part of risk assessment
@@ -188,7 +188,7 @@ Culture and Organization:
       level: 4
       dependsOn:
       - Creation of simple abuse stories
-      samm2: threat-assessment|B|2
+      samm2: D-TA-2-B
       iso27001-2017:
       - not explicitly covered by ISO 27001
       - may be part of project management
@@ -213,7 +213,7 @@ Culture and Organization:
         resources: 1
       usefulness: 4
       level: 3
-      samm2: threat-assessment|B|2
+      samm2: D-TA-2-B
       iso27001-2017:
       - not explicitly covered by ISO 27001
       - may be part of project management

--- a/data/dimensions-subdimensions-activties/CultureAndOrganization/EducationAndGuidance.yaml
+++ b/data/dimensions-subdimensions-activties/CultureAndOrganization/EducationAndGuidance.yaml
@@ -27,7 +27,7 @@ Culture and Organization:
       usefulness: 3
       level: 1
       samm2:
-        - education-and-guidance|A|1
+        - G-EG-1-A
       implementation:
       - *juice-shop
       - name: OWASP Cheatsheet Series
@@ -47,7 +47,7 @@ Culture and Organization:
       usefulness: 4
       level: 4
       samm2:
-        - education-and-guidance|A|3
+        - G-EG-3-A
       iso27001-2017:
         - 7.2.2
       implementation:
@@ -72,7 +72,7 @@ Culture and Organization:
       usefulness: 4
       level: 2
       samm2:
-        - education-and-guidance|A|1
+        - G-EG-1-A
       iso27001-2017:
       - 7.2.2
       md-description: |
@@ -105,7 +105,7 @@ Culture and Organization:
       usefulness: 3
       level: 1
       samm2:
-        - education-and-guidance|A|1
+        - G-EG-1-A
       iso27001-2017:
       - security consulting is missing in ISO 27001 may be
       - 6.1.1
@@ -129,8 +129,8 @@ Culture and Organization:
       usefulness: 5
       level: 2
       samm2:
-        - threat-assessment|B|2
-        - education-and-guidance|A|1
+        - D-TA-2-B
+        - G-EG-1-A
       iso27001-2017:
       - security champions are missing in ISO 27001
       - 7.2.2
@@ -158,9 +158,9 @@ Culture and Organization:
         The goals of the position are to increase effectiveness and efficiency of application security and compliance and to strengthen the relationship between various teams and Information Security. To achieve these objectives, “Security Champions” assist with researching, verifying, and prioritizing security and compliance related software defects. They are involved in all Risk Assessments, Threat Assessments, and Architectural Reviews to help identify opportunities to remediate security defects by making the architecture of the application more resilient and reducing the attack threat surface.
         Source: [OWASP SAMM](https://owaspsamm.org/model/governance/education-and-guidance/stream-b/)
       samm2:
-        - education-and-guidance|B|1
-        - education-and-guidance|B|2
-        - education-and-guidance|B|3
+        - G-EG-1-B
+        - G-EG-2-B
+        - G-EG-3-B
       iso27001-2017:
       - security champions are missing in ISO 27001 most likely
       - 7.2.1
@@ -206,7 +206,7 @@ Culture and Organization:
       - 12.7.1
       implementation: []
       samm2:
-        - education-and-guidance|A|2
+        - G-EG-2-A
     Conduction of collaborative team security checks:
       risk:
       - Development teams limited insight over security practices.
@@ -219,8 +219,8 @@ Culture and Organization:
       usefulness: 2
       level: 4
       samm2:
-        - education-and-guidance|A|1
-        - education-and-guidance|A|2
+        - G-EG-1-A
+        - G-EG-2-A
       iso27001-2017:
       - Mutual security testing is not explicitly required in ISO 27001 may be
       - 7.2.2
@@ -246,7 +246,7 @@ Culture and Organization:
         tags: []
         url: https://builditbreakit.org/
       samm2:
-        - education-and-guidance|A|2
+        - G-EG-2-A
     Conduction of war games:
       risk:
       - Understanding incident response plans during an incident is hard and ineffective.
@@ -266,7 +266,7 @@ Culture and Organization:
       - 16.1.5
       implementation: []
       samm2:
-        - education-and-guidance|A|2
+        - G-EG-2-A
     Reward of good communication:
       risk:
       - Employees are not getting excited about security.
@@ -279,7 +279,7 @@ Culture and Organization:
         resources: 1
       usefulness: 3
       level: 2
-      samm2: education-and-guidance|B|1
+      samm2: G-EG-1-B
       iso27001-2017:
       - not required by ISO 27001
       - interestingly enough A7.2.3 is requiring a process to handle misconduct but
@@ -313,7 +313,7 @@ Culture and Organization:
           software design and sprint planning to provide guidance and suggestions.
       level: 4
       samm2:
-        - education-and-guidance|B|3
+        - G-EG-3-B
       iso27001-2017:
       - 7.1.1
     Simple Mob Hacking:
@@ -349,4 +349,4 @@ Culture and Organization:
         - *juice-shop
         - *dvwa
       samm2:
-        - education-and-guidance|A|1
+        - G-EG-1-A

--- a/data/dimensions-subdimensions-activties/Implementation/ApplicationHardening.yaml
+++ b/data/dimensions-subdimensions-activties/Implementation/ApplicationHardening.yaml
@@ -42,7 +42,7 @@ Implementation:
       - name: OWASP MASVS
         tags: []
         url: https://github.com/OWASP/owasp-masvs
-      samm2: software-requirements|A|1
+      samm2: D-SR-1-A
       iso27001-2017:
       - hardening is not explicitly covered by ISO 27001 - too specific
       - 13.1.3
@@ -69,7 +69,7 @@ Implementation:
       - name: OWASP MASVS
         tags: []
         url: https://github.com/OWASP/owasp-masvs
-      samm2: software-requirements|A|2
+      samm2: D-SR-2-A
       iso27001-2017:
       - hardening is not explicitly covered by ISO 27001 - too specific
       - 13.1.3
@@ -97,7 +97,7 @@ Implementation:
       - name: OWASP MASVS
         tags: []
         url: https://github.com/OWASP/owasp-masvs
-      samm2: software-requirements|A|3
+      samm2: D-SR-3-A
       iso27001-2017:
       - hardening is not explicitly covered by ISO 27001 - too specific
       - 13.1.3
@@ -125,7 +125,7 @@ Implementation:
       - name: OWASP MASVS
         tags: []
         url: https://github.com/OWASP/owasp-masvs
-      samm2: software-requirements|A|3
+      samm2: D-SR-3-A
       iso27001-2017:
       - hardening is not explicitly covered by ISO 27001 - too specific
       - 13.1.3

--- a/data/dimensions-subdimensions-activties/Implementation/InfrastructureHardening.yaml
+++ b/data/dimensions-subdimensions-activties/Implementation/InfrastructureHardening.yaml
@@ -46,7 +46,7 @@ Implementation:
       - <<: *cloud-attack-matrix
       - <<: *container-attack-matrix
       - <<: *kubernetes-attack-matrix
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - system hardening is not explicitly covered by ISO 27001 - too specific
       - 13.1.3
@@ -61,7 +61,7 @@ Implementation:
         resources: 5
       usefulness: 3
       level: 2
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - virtual environments are not explicitly covered by ISO 27001 - too specific
       - 13.1.3
@@ -77,7 +77,7 @@ Implementation:
         resources: 1
       usefulness: 3
       level: 2
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 14.2.1
@@ -104,7 +104,7 @@ Implementation:
         tags: []
       - name: firewalls
         tags: []
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - virtual environments are not explicitly covered by ISO 27001 - too specific
       - 13.1.3
@@ -125,7 +125,7 @@ Implementation:
         tags: []
       - name: firewalls
         tags: []
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - virtual environments are not explicitly covered by ISO 27001 - too specific
       - 13.1.3
@@ -153,7 +153,7 @@ Implementation:
         tags: []
       - name: Jenkinsfile
         tags: []
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 12.1.1
@@ -175,7 +175,7 @@ Implementation:
         tags: []
       - name: strace
         tags: []
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - system hardening is not explicitly covered by ISO 27001 - too specific
     Immutable Infrastructure:
@@ -195,7 +195,7 @@ Implementation:
       implementation:
       - name: Remove direct access to infrastructure
         tags: []
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 17.2.1
@@ -210,7 +210,7 @@ Implementation:
         resources: 5
       usefulness: 3
       level: 4
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001
       implementation: []
@@ -232,7 +232,7 @@ Implementation:
       dependsOn:
       - Defined deployment process
       - Infrastructure as Code
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - 12.1.4
       - 17.2.1
@@ -257,7 +257,7 @@ Implementation:
       dependsOn:
       - Defined deployment process
       - Defined build process
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - 9.4.1
     2FA:
@@ -304,7 +304,7 @@ Implementation:
         tags: []
       - name: VPN
         tags: []
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - 9.4.1
     Usage of a chaos monkey:
@@ -320,7 +320,7 @@ Implementation:
         resources: 5
       usefulness: 3
       level: 4
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 17.1.3
@@ -348,7 +348,7 @@ Implementation:
         tags: []
       dependsOn:
       - Defined build process
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
     Usage of test and production environments:
@@ -363,7 +363,7 @@ Implementation:
       level: 1
       dependsOn:
       - Defined deployment process
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 12.1.4
@@ -382,7 +382,7 @@ Implementation:
       level: 3
       dependsOn:
       - Defined deployment process
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 12.1.1
@@ -403,7 +403,7 @@ Implementation:
       level: 2
       dependsOn:
       - Applications are running in virtualized environments
-      samm2: o-environment-management|A|1
+      samm2: O-EM-1-A
       iso27001-2017:
       - virtual environments are not explicitly covered by ISO 27001 - too specific
       - 12.1.3

--- a/data/dimensions-subdimensions-activties/InformationGathering/Logging.yaml
+++ b/data/dimensions-subdimensions-activties/InformationGathering/Logging.yaml
@@ -30,7 +30,7 @@ Information Gathering:
       dependsOn:
         - Visualized logging
         - Alerting
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 12.4.1
@@ -53,7 +53,7 @@ Information Gathering:
           tags: []
         - name: bash
           tags: []
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 12.4.1
@@ -90,7 +90,7 @@ Information Gathering:
         - name: bash
           tags: ["tool"]
         - *loggingCheatSheet
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
         - 12.4.1
     Centralized system logging:
@@ -109,7 +109,7 @@ Information Gathering:
       implementation:
         - *rsyslog
         - *logstash
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 12.4.1
@@ -128,7 +128,7 @@ Information Gathering:
       dependsOn:
         - Visualized logging
         - Alerting
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 12.4.1
@@ -152,7 +152,7 @@ Information Gathering:
       implementation:
         - name: ELK-Stack
           tags: []
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 12.4.1

--- a/data/dimensions-subdimensions-activties/InformationGathering/Monitoring.yaml
+++ b/data/dimensions-subdimensions-activties/InformationGathering/Monitoring.yaml
@@ -14,7 +14,7 @@ Information Gathering:
       dependsOn:
       - Simple application metrics
       - Visualized metrics
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - 12.1.3
       implementation: []
@@ -32,7 +32,7 @@ Information Gathering:
       dependsOn:
       - Simple application metrics
       - Visualized metrics
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - 12.6.1
       implementation: []
@@ -49,7 +49,7 @@ Information Gathering:
       level: 2
       dependsOn:
       - Visualized metrics
-      samm2: o-operational-management|B|3
+      samm2: O-DM-3-B
       iso27001-2017:
       - 16.1.2
       - 16.1.4
@@ -77,7 +77,7 @@ Information Gathering:
         tags: []
         url: https://ht.transparencytoolkit.org/FileServer/FileServer/OLD
         description: https://ht.transparencytoolkit.org/FileServer/FileServer/OLD%20Fileserver/books/SICUREZZA/Addison.Wesley.Security.Metrics.Mar.2007.pdf
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
     Deactivation of unused metrics:
@@ -92,7 +92,7 @@ Information Gathering:
       level: 3
       dependsOn:
       - Visualized metrics
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 12.1.3
@@ -113,7 +113,7 @@ Information Gathering:
       dependsOn:
       - Visualized metrics
       - Filter outgoing traffic
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - 12.4.1
       - 13.1.1
@@ -128,7 +128,7 @@ Information Gathering:
         resources: 2
       usefulness: 2
       level: 3
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 12.1.3
@@ -145,7 +145,7 @@ Information Gathering:
       level: 4
       dependsOn:
       - Grouping of metrics
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - not explicitly covered by ISO 27001
       implementation: []
@@ -162,7 +162,7 @@ Information Gathering:
       level: 4
       dependsOn:
       - Grouping of metrics
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 16.1.5
@@ -181,7 +181,7 @@ Information Gathering:
       implementation:
       - name: Prometheus
         tags: []
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
       - 12.4.1
     Simple system metrics:
@@ -200,7 +200,7 @@ Information Gathering:
       implementation:
       - name: collected
         tags: []
-      samm2: o-incident-management|A|1
+      samm2: O-IM-1-A
       iso27001-2017:
       - 12.1.3
     Targeted alerting:
@@ -217,7 +217,7 @@ Information Gathering:
       level: 3
       dependsOn:
       - Alerting
-      samm2: o-operational-management|B|3
+      samm2: O-DM-3-B
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 16.1.5
@@ -235,7 +235,7 @@ Information Gathering:
       dependsOn:
       - Simple application metrics
       - Simple system metrics
-      samm2: o-incident-management|A|2
+      samm2: O-IM-2-A
       iso27001-2017:
       - 12.1.3
       implementation: []

--- a/data/dimensions-subdimensions-activties/TestAndVerification/ApplicationTests.yaml
+++ b/data/dimensions-subdimensions-activties/TestAndVerification/ApplicationTests.yaml
@@ -12,7 +12,7 @@ Test and Verification:
         resources: 3
       usefulness: 3
       level: 4
-      samm2: v-security-testing|B|3
+      samm2: V-ST-3-B
       iso27001-2017:
       - 14.2.3
       - 14.2.8
@@ -31,7 +31,7 @@ Test and Verification:
       implementation:
       - name: HttpUnit
         tags: []
-      samm2: v-security-testing|B|3
+      samm2: V-ST-3-B
       iso27001-2017:
       - 14.2.3
       - 14.2.8
@@ -55,7 +55,7 @@ Test and Verification:
       - name: Karma
         tags: []
         url: https://karma-runner.github.io
-      samm2: v-security-testing|B|3
+      samm2: V-ST-3-B
       iso27001-2017:
       - 14.2.3
       - 14.2.8
@@ -74,7 +74,7 @@ Test and Verification:
       implementation: []
       dependsOn:
       - Defined deployment process
-      samm2: v-security-testing|B|3
+      samm2: V-ST-3-B
       iso27001-2017:
       - 14.2.3
       - 14.2.8

--- a/data/dimensions-subdimensions-activties/TestAndVerification/Consolidation.yaml
+++ b/data/dimensions-subdimensions-activties/TestAndVerification/Consolidation.yaml
@@ -29,7 +29,7 @@ Test and Verification:
         - *defectdojo
         - *purify
       references:
-        samm2: i-defect-management|B|1
+        samm2: I-DM-1-B
         iso27001-2017:
         - 16.1.4
         - 8.2.1
@@ -50,7 +50,7 @@ Test and Verification:
       usefulness: 4
       level: 1
       references:
-        samm2: i-defect-management|A|2
+        samm2: I-DM-2-A
         iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 12.6.1
@@ -81,7 +81,7 @@ Test and Verification:
         description: 'At DAST (Dynamic Application Security Testing): vulnerabilities
           are classified and can be assigned to server-side and client-side teams.'
       references:
-        samm2: i-defect-management|B|2
+        samm2: I-DM-2-B
         iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 16.1.4
@@ -101,7 +101,7 @@ Test and Verification:
       usefulness: 2
       level: 4
       implementation: []
-      samm2: i-defect-management|B|2
+      samm2: I-DM-2-B
       iso27001-2017:
       - 16.1.4
       - 8.2.1
@@ -126,7 +126,7 @@ Test and Verification:
       - name: Purify
         tags: []
         url: https://github.com/faloker/purify/
-      samm2: i-defect-management|A|2
+      samm2: I-DM-2-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 16.1.6
@@ -149,7 +149,7 @@ Test and Verification:
       - *defectdojo
       - *purify
       references:
-        samm2: i-defect-management|B|1
+        samm2: I-DM-1-B
         iso27001-2017:
         - 16.1.4
         - 8.2.1
@@ -165,7 +165,7 @@ Test and Verification:
         resources: 1
       usefulness: 2
       level: 4
-      samm2: i-defect-management|B|2
+      samm2: I-DM-2-B
       iso27001-2017:
       - 16.1.4
       - 12.6.1
@@ -183,7 +183,7 @@ Test and Verification:
       level: 1
       comment: False positive analysis, specially for static analysis, is time consuming.
       references:
-        samm2: i-defect-management|B|2
+        samm2: I-DM-2-B
         iso27001-2017:
         - 16.1.4
         - 12.6.1
@@ -200,7 +200,7 @@ Test and Verification:
       level: 3
       comment: False positive analysis, specially for static analysis, is time consuming.
       references:
-        samm2: i-defect-management|B|2
+        samm2: I-DM-2-B
         iso27001-2017:
         - 16.1.4
         - 12.6.1
@@ -221,7 +221,7 @@ Test and Verification:
         - *defectdojo
         - *purify
       references:
-        samm2: i-defect-management|B|1
+        samm2: I-DM-1-B
         iso27001-2017:
         - 12.6.1
         - 16.1.3

--- a/data/dimensions-subdimensions-activties/TestAndVerification/DynamicDepthForApplications.yaml
+++ b/data/dimensions-subdimensions-activties/TestAndVerification/DynamicDepthForApplications.yaml
@@ -34,7 +34,7 @@ Test and Verification:
       - name: OWASP Code Pulse
         tags: []
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - part of periodic review, PDCA
@@ -53,7 +53,7 @@ Test and Verification:
       dependsOn:
       - Usage of different roles
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - 14.2.3
         - 14.2.8
@@ -79,7 +79,7 @@ Test and Verification:
       dependsOn:
       - Usage of different roles
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
     Coverage of more input vectors:
@@ -98,7 +98,7 @@ Test and Verification:
       dependsOn:
       - Usage of different roles
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
       implementation: []
@@ -119,7 +119,7 @@ Test and Verification:
       dependsOn:
       - Usage of different roles
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - 14.2.8
         - 14.2.3
@@ -136,7 +136,7 @@ Test and Verification:
       dependsOn:
       - Simple Scan
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - 14.2.3
         - 14.2.8
@@ -160,7 +160,7 @@ Test and Verification:
       - *zap
       - name: Arachni
       references:
-        samm2: v-security-testing|A|1
+        samm2: V-ST-1-A
         iso27001-2017:
         - 14.2.3
         - 14.2.8
@@ -178,7 +178,7 @@ Test and Verification:
       dependsOn:
       - Simple Scan
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - not explicitly covered by ISO 27001 - too specific
         - 14.2.3
@@ -201,7 +201,7 @@ Test and Verification:
       implementation:
       - *secureCodeBox
       references:
-        samm2: v-security-testing|A|2
+        samm2: V-ST-2-A
         iso27001-2017:
         - 12.6.1
         - 14.2.5

--- a/data/dimensions-subdimensions-activties/TestAndVerification/DynamicDepthForInfrastructure.yaml
+++ b/data/dimensions-subdimensions-activties/TestAndVerification/DynamicDepthForInfrastructure.yaml
@@ -20,7 +20,7 @@ Test and Verification:
         resources: 5
       usefulness: 3
       level: 4
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - 12.1.3
       - 14.2.3
@@ -64,7 +64,7 @@ Test and Verification:
       implementation:
       - name: HTC Hydra
         tags: []
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 9.4.3
     Test network segmentation:
@@ -84,7 +84,7 @@ Test and Verification:
         tags: []
         url: https://github.com/controlplaneio/netassert
       dependsOn: Segmented networks for virtual environments
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 13.1.3
       - 14.2.3
@@ -108,7 +108,7 @@ Test and Verification:
       - name: OWASP Amass
         tags: []
         url: https://github.com/OWASP/Amass
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - 13.1.3
       - 14.2.3
@@ -125,9 +125,8 @@ Test and Verification:
       level: 4
       implementation:
         - *K8sPurger
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
         - 13.1.3
         - 14.2.3
         - 14.2.8
-

--- a/data/dimensions-subdimensions-activties/TestAndVerification/StaticDepthForApplications.yaml
+++ b/data/dimensions-subdimensions-activties/TestAndVerification/StaticDepthForApplications.yaml
@@ -15,7 +15,7 @@ Test and Verification:
         tags: []
       dependsOn:
       - Defined build process
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - not explicitly covered by ISO 27001 - too specific
       - 14.2.1
@@ -33,7 +33,7 @@ Test and Verification:
       dependsOn:
       - Static analysis for important client side components
       - Static analysis for important server side components
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
       implementation: []
@@ -59,7 +59,7 @@ Test and Verification:
       dependsOn:
       - Static analysis for important client side components
       - Static analysis for important server side components
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
     Static analysis for important client side components:
@@ -85,7 +85,7 @@ Test and Verification:
         tags: []
         url: https://github.com/ing-bank/bdd-mobile-security-automation-framework
         description: '[bdd-mobile-security-automation-framework](https://github.com/ing-bank/bdd-mobile-security-automation-framework)'
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
       dependsOn:
@@ -111,7 +111,7 @@ Test and Verification:
         tags: []
       dependsOn:
       - Defined build process
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
     Stylistic analysis:
@@ -128,7 +128,7 @@ Test and Verification:
       implementation:
       - name: PMD
         tags: []
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
       - 14.2.1
@@ -152,7 +152,7 @@ Test and Verification:
       - name: npm audit
         tags: []
         url: https://docs.npmjs.com/cli/audit
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
     Test of server side components with known vulnerabilities:
@@ -171,7 +171,7 @@ Test and Verification:
       implementation:
       - name: OWASP Dependency Check
         tags: []
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
     Usage of multiple analyzers:
@@ -185,7 +185,7 @@ Test and Verification:
         resources: 5
       usefulness: 1
       level: 4
-      samm2: v-security-testing|A|3
+      samm2: V-ST-3-A
       iso27001-2017:
       - 12.6.1
       - 14.2.1

--- a/data/dimensions-subdimensions-activties/TestAndVerification/StaticDepthForInfrastructure.yaml
+++ b/data/dimensions-subdimensions-activties/TestAndVerification/StaticDepthForInfrastructure.yaml
@@ -31,7 +31,7 @@ Test and Verification:
         url: https://github.com/wagoodman/dive
       - name: Cluster Scanner (will be open sourced soon) to check different aspects
         tags: []
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
     Test the definition of virtualized environments:
       risk:
       - The definition of virtualized environments (e.g. via <i>Dockerfile</i>) might
@@ -50,7 +50,7 @@ Test and Verification:
       - name: Deployment with kube-score
         tags: []
         url: https://github.com/zegl/kube-score
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - system hardening, virtual environments are not explicitly covered by ISO 27001
         - too specific
@@ -74,7 +74,7 @@ Test and Verification:
       - name: kubesec
         tags: []
         url: https://kubesec.io/
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - system hardening is not explicitly covered by ISO 27001 - too specific
       - 12.6.1
@@ -106,7 +106,7 @@ Test and Verification:
       - name: Vuls
         tags: []
         url: https://github.com/future-architect/vuls
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - 12.6.1
       - 14.2.1
@@ -132,7 +132,7 @@ Test and Verification:
       - name: Vuls
         tags: []
         url: https://github.com/future-architect/vuls
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - 12.6.1
       - 14.2.1
@@ -152,7 +152,7 @@ Test and Verification:
       - name: kube-bench
         tags: []
         url: https://github.com/aquasecurity/kube-bench
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - system hardening is not explicitly covered by ISO 27001 - too specific
       - 12.6.1
@@ -176,7 +176,7 @@ Test and Verification:
       - name: go-pillage-registries
         tags: []
         url: https://github.com/nccgroup/go-pillage-registries
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - vcs usage is not explicitly covered by ISO 27001 - too specific
       - 9.4.3
@@ -193,7 +193,7 @@ Test and Verification:
       usefulness: 2
       level: 3
       implementation: []
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - 12.6.1
       - 14.2.5
@@ -216,7 +216,7 @@ Test and Verification:
         tags: []
         description: Registries like quay, dockerhub provide (commercial) offerings,
           often not suitable for distroless images
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
     Check for new image version:
@@ -230,7 +230,7 @@ Test and Verification:
       usefulness: 2
       level: 3
       implementation: []
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
       - 14.2.5
@@ -249,6 +249,6 @@ Test and Verification:
       usefulness: 3
       level: 3
       implementation: []
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.2.1

--- a/data/dimensions-subdimensions-activties/TestAndVerification/Test-Intensity.yaml
+++ b/data/dimensions-subdimensions-activties/TestAndVerification/Test-Intensity.yaml
@@ -12,7 +12,7 @@ Test and Verification:
       usefulness: 2
       level: 2
       implementation: []
-      samm2: i-secure-build|A|3
+      samm2: I-SB-3-A
       iso27001-2017:
       - 14.2.3
       - 14.2.8
@@ -30,7 +30,7 @@ Test and Verification:
         resources: 3
       usefulness: 2
       level: 3
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 14.2.2
       - 14.2.3
@@ -52,7 +52,7 @@ Test and Verification:
         resources: 1
       usefulness: 1
       level: 2
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
       - 14.2.1
@@ -68,7 +68,7 @@ Test and Verification:
         resources: 1
       usefulness: 1
       level: 1
-      samm2: v-security-testing|A|1
+      samm2: V-ST-1-A
       iso27001-2017:
       - 12.6.1
       - 14.2.1
@@ -85,7 +85,7 @@ Test and Verification:
         resources: 5
       usefulness: 3
       level: 1
-      samm2: v-security-testing|A|2
+      samm2: V-ST-2-A
       iso27001-2017:
       - 12.6.1
       - 14.2.1


### PR DESCRIPTION
## This PR

- renames SAMM activities based on the Activities existing in https://github.com/OWASP/samm/blob/master/Supporting%20Resources/v2.0/Datamodel/Datafiles/ 

It is thus possible to retrieve all activity description using `curl https://raw.githubusercontent.com/OWASP/samm/master/Supporting%20Resources/v2.0/Datamodel/Datafiles/Activity%20${LABEL}.yml`

The resulting information can be displayed on a webapp directly by the browser without being embedded in dsomm.