### PR TITLE
Fix dependsOn mistyped

### DIFF
--- a/data/dimensions-subdimensions-activities/TestAndVerification/DynamicDepthForInfrastructure.yaml
+++ b/data/dimensions-subdimensions-activities/TestAndVerification/DynamicDepthForInfrastructure.yaml
@@ -78,7 +78,8 @@ Test and Verification:
       level: 2
       implementation:
       - $ref: data/dimensions-subdimensions-activities/implementations.yaml#/implementations/netassert
-      dependsOn: Segmented networks for virtual environments
+      dependsOn:
+      - Segmented networks for virtual environments
       samm2: V-ST-2-A
       iso27001-2017:
       - 13.1.3


### PR DESCRIPTION
A Fatal error is throwed in `details.php` because dependsOn is filled as a string instead of an array
```
Fatal error: Uncaught TypeError: implode(): Argument #2 ($array) must be of type ?array, string given in /var/www/html/detail.php:81 Stack trace: #0 /var/www/html/detail.php(81): implode(', ', 'Segmented netwo...') #1 /var/www/html/report.php(68): printDetail('Test and Verifi...', 'Dynamic depth f...', 'Test network se...', Array, true) #2 {main} thrown in /var/www/html/detail.php on line 81
```

To fix it I just updated the involved yaml file