### PR TITLE
Typo Fixes for docker run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In case you would like to perform a DevSecOps assessment, the following tools ar
 ## Container
 
 1. Install [Docker](https://www.docker.com)
-2. Run `docker run --rm -p 8080:8080 wurstbrot/dsomm:latest
+2. Run `docker run --rm -p 8080:8080 wurstbrot/dsomm:latest`
 3. Browse to <http://localhost:8080> (on macOS and Windows browse to <http://192.168.99.100:8080> if you are using docker-machine instead
    of the native docker installation)
 

--- a/src/assets/Markdown Files/README.md
+++ b/src/assets/Markdown Files/README.md
@@ -57,7 +57,7 @@ In case you would like to perform a DevSecOps assessment, the following tools ar
 ## Container
 
 1. Install [Docker](https://www.docker.com)
-2. Run `docker run --rm -p 8080:80 wurstbrot/dsomm:latest
+2. Run `docker run --rm -p 8080:8080 wurstbrot/dsomm:latest`
 3. Browse to <http://localhost:8080> (on macOS and Windows browse to <http://192.168.99.100:8080> if you are using docker-machine instead
    of the native docker installation)
 


### PR DESCRIPTION
Formatting fix in the readme, and command fix on the usage page