### PR TITLE
Set Task Description page to start with its information visible

### DIFF
--- a/src/app/component/task-description/task-description.component.ts
+++ b/src/app/component/task-description/task-description.component.ts
@@ -174,6 +174,7 @@ export class TaskDescriptionComponent implements OnInit {
         data['isImplemented'],
         false
       );
+      this.openall();
     });
   }
 


### PR DESCRIPTION
Reducing the number of clicks on a web page is considered good usability.
Currently a user will always need to click "Expand all" every time they visit the Task Description page, to learn about a new task. For example, reading information about each tasks under "Build and Deployment / Deployment" today would require 22 clicks (plus 10 clicks on the browser Back button). This patch reduces the number of page clicks down to 11.