### PR TITLE
Applesilicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:18.7-alpine AS build
+
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
-RUN npm install
+RUN apk add --upgrade python3 build-base \
+ && npm install
 COPY . .
 RUN npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,15 @@ RUN npm run build
 
 FROM wurstbrot/dsomm-yaml-generation as yaml
 
-FROM bitnami/nginx:latest
-COPY --from=yaml /var/www/html/src/assets/YAML/generated/generated.yaml /app/src/assets/YAML/generated/generated.yaml
-COPY nginx/location.conf /opt/bitnami/nginx/conf/bitnami/location.conf
-COPY --from=build /usr/src/app/dist/dsomm/ /app
+FROM nginx:alpine
+
+RUN chown -R nginx:nginx /var/cache/nginx \
+ && chown -R nginx:nginx /var/log/nginx \
+ && touch /var/run/nginx.pid \
+ && chown -R nginx:nginx /var/run/nginx.pid
+
+COPY --from=yaml ["/var/www/html/src/assets/YAML/generated/generated.yaml", "/usr/share/nginx/html/assets/YAML/generated/generated.yaml"]
+COPY ["nginx/default.conf", "/etc/nginx/conf.d/"]
+COPY --from=build ["/usr/src/app/dist/dsomm/", "/usr/share/nginx/html/"]
+
+USER nginx

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,20 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/nginx/location.conf
+++ b/nginx/location.conf
@@ -1,4 +1,0 @@
-location / {
-    root /app;
-    try_files $uri $uri/ /index.html =404;
-}


### PR DESCRIPTION
Enable build and executing on Apple Silicon by added required build deps to the `node-alpine` image and switching out the nginx image to the official one with modifications to Dockerfile to allow rootless operation of nginx. 