### PR TITLE
Refactor CSS styles for sidenav-menu and menu-close (#433 closs)

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,4 +1,3 @@
-
 .main-container {
   width: 100%;
   height: 100%;
@@ -11,25 +10,16 @@
 }
 
 .sidenav-menu {
-  padding: 20px;
+  padding: 10px;
+  padding-right: 30px;
 }
 
 .menu-close {
   position: absolute;
   right: 0;
-  top: 2px;
+  top: 15px;
   background: transparent;
   border: 0;
-  color: #ddd;
-}
-
-.github-fork-ribbon:before {
-  background-color: #333;
-}
-
-@media only screen and (max-width: 750px) {
-    .github-fork-ribbon {
-        display: none;
-      }
-    
+  cursor: pointer;
+  color: #4caf50;
 }


### PR DESCRIPTION
Adjusted padding and positioning for sidenav-menu and menu-close styles.

Old Look

<img width="552" height="835" alt="image" src="https://github.com/user-attachments/assets/86cbb38e-1b09-402b-913f-c95ad1a2127e" />

New Look

<img width="580" height="833" alt="image" src="https://github.com/user-attachments/assets/9db69af1-7598-43f5-9a5c-93326999c79f" />
