### PR TITLE
 Improve circular heatmap positioning

### DIFF
--- a/src/app/pages/circular-heatmap/circular-heatmap.component.css
+++ b/src/app/pages/circular-heatmap/circular-heatmap.component.css
@@ -41,6 +41,7 @@
 #chart {
   width: 100%;
   max-width: min(100vh - 60px, 100vw - 60px);
+  margin-left: 20px;
 }
 
 .downloadButtonClass {


### PR DESCRIPTION
Moved the circular heatmap chart 20px to the right to improve visual alignment and provide better spacing from the left edge. This small adjustment enhances the overall layout and makes the chart easier to view.
