### PR TITLE
fix: Copy README: Add a second's slack before outputing the warning message

### DIFF
--- a/scripts/copy-readme.js
+++ b/scripts/copy-readme.js
@@ -33,7 +33,7 @@ try {
     if (targetStats.mtimeMs == sourceStats.mtimeMs) {
         copyNeeded = false;
     }
-    if (targetStats.mtimeMs > sourceStats.mtimeMs) {
+    if (targetStats.mtimeMs > sourceStats.mtimeMs + 1001) {
         console.warn('===============================================================');
         console.warn('⚠️  WARNING: Did you edit the README.md copy under `assets`?');
         console.warn('The assets readme gets overwritten during the build process.');


### PR DESCRIPTION
When copying README the utime is set identical. But the CI pipeline returned 9 ms difference => warning is shown. 

This PR allows the assets-README to be up to 1000 ms newer then the root README, without incorrectly displaying a warning. 

