### PR TITLE
fix: Update README references

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,9 +121,9 @@ Multi-language support is not currently planned.
 
 [![Timo Pagel IT-Consulting](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/timo-pagel-logo.png)](https://pagel.pro)
 
-[![Apprio Inc](https://github.com/wurstbrot/DevSecOps-MaturityModel/raw/master-old/assets/images/Apiiro_black_logo.png)](https://apiiro.com/)
+[![Apprio Inc](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/raw/master-old/assets/images/Apiiro_black_logo.png)](https://apiiro.com/)
 
-[![Heroku (hosting)](https://github.com/wurstbrot/DevSecOps-MaturityModel/raw/main/src/assets/images/sponsors/heroku.png)](https://www.heroku.com/open-source-credit-program)
+[![Heroku (hosting)](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/raw/main/src/assets/images/sponsors/heroku.png)](https://www.heroku.com/open-source-credit-program)
 
 # Donations
 
@@ -140,7 +140,7 @@ An example attribution by changing the content:
 The OWASP DevSecOps Maturity Model and any contributions are Copyright © by Timo Pagel 2017-2025.
 
 
-For customized DSOMM, take a look at https://github.com/wurstbrot/DevSecOps-MaturityModel-custom. 
+For customized DSOMM, take a look at https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel-custom. 
 
 You can download your current state from the circular heatmap and mount it again via 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Changes to the maturity model content are displayed at the release page of [DevS
 
 # Community
 Join #dsomm in [OWASP Slack](https://owasp.slack.com/join/shared_invite/zt-g398htpy-AZ40HOM1WUOZguJKbblqkw#/).
-Create issues or even better Pull Requests in [github](https://github.com/wurstbrot/DevSecOps-MaturityModel/).
+Create issues or even better Pull Requests in [github](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/).
 
 # Slides and talks
 * [Video: OWASP (DevSecOps) Projects, 2021-04-28, OWASP Stammtisch Frankfurt](https://www.youtube.com/watch?v=8webiYnF56A)
@@ -62,7 +62,7 @@ In case you would like to perform a DevSecOps assessment, the following tools ar
 3. Browse to <http://localhost:8080> (on macOS and Windows browse to <http://192.168.99.100:8080> if you are using docker-machine instead
    of the native docker installation)
 
-For customized DSOMM, take a look at https://github.com/wurstbrot/DevSecOps-MaturityModel-custom. 
+For customized DSOMM, take a look at https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel-custom. 
 
 You can download your current state from the circular heatmap and mount it again via 
 
@@ -181,7 +181,7 @@ Multilanguage support is not given currently and not planned.
 
 [![Timo Pagel IT-Consulting](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/timo-pagel-logo.png)](https://pagel.pro)
 
-[![Apprio Inc](https://github.com/wurstbrot/DevSecOps-MaturityModel/raw/master-old/assets/images/Apiiro_black_logo.png)](https://apiiro.com/)
+[![Apprio Inc](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/raw/master-old/assets/images/Apiiro_black_logo.png)](https://apiiro.com/)
 
 # Donations
 

--- a/src/app/component/sidenav-buttons/sidenav-buttons.component.html
+++ b/src/app/component/sidenav-buttons/sidenav-buttons.component.html
@@ -3,7 +3,7 @@
     <mat-icon mat-list-icon color="primary">{{ Icons[i] }}</mat-icon>
     <h3 mat-line>{{ Options[i] }}</h3>
   </a>
-  <a mat-list-item href="https://github.com/wurstbrot/DevSecOps-MaturityModel/" target="_blank">
+  <a mat-list-item href="https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/" target="_blank">
     <mat-icon mat-list-icon color="primary" svgIcon="github"></mat-icon>
     <h3 mat-line>GitHub</h3>
   </a>

--- a/src/assets/Markdown Files/README.md
+++ b/src/assets/Markdown Files/README.md
@@ -31,7 +31,7 @@ Changes to the maturity model content are displayed at the release page of [DevS
 
 # Community
 Join #dsomm in [OWASP Slack](https://owasp.slack.com/join/shared_invite/zt-g398htpy-AZ40HOM1WUOZguJKbblqkw#/).
-Create issues or even better Pull Requests in [github](https://github.com/wurstbrot/DevSecOps-MaturityModel/).
+Create issues or even better Pull Requests in [github](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/).
 
 # Slides and talks
 * [Video: OWASP (DevSecOps) Projects, 2021-04-28, OWASP Stammtisch Frankfurt](https://www.youtube.com/watch?v=8webiYnF56A)
@@ -63,7 +63,7 @@ In case you would like to perform a DevSecOps assessment, the following tools ar
 3. Browse to <http://localhost:8080> (on macOS and Windows browse to <http://192.168.99.100:8080> if you are using docker-machine instead
    of the native docker installation)
 
-For customized DSOMM, take a look at https://github.com/wurstbrot/DevSecOps-MaturityModel-custom. In case you would like to have perform an assessment for multiple teams, iterate from port 8080 to 8XXX, depending of the size of your team.
+For customized DSOMM, take a look at https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel-custom. In case you would like to have perform an assessment for multiple teams, iterate from port 8080 to 8XXX, depending of the size of your team.
 
 You can download your current state from the circular heatmap and mount it again via 
 
@@ -164,9 +164,9 @@ Multilanguage support is not given currently and not planned.
 
 [![Timo Pagel IT-Consulting](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/timo-pagel-logo.png)](https://pagel.pro)
 
-[![Apprio Inc](https://github.com/wurstbrot/DevSecOps-MaturityModel/raw/master-old/assets/images/Apiiro_black_logo.png)](https://apiiro.com/)
+[![Apprio Inc](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/raw/master-old/assets/images/Apiiro_black_logo.png)](https://apiiro.com/)
 
-[![Heroku (hosting)](https://github.com/wurstbrot/DevSecOps-MaturityModel/raw/main/src/assets/images/sponsors/heroku.png)](https://www.heroku.com/open-source-credit-program)
+[![Heroku (hosting)](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel/raw/main/src/assets/images/sponsors/heroku.png)](https://www.heroku.com/open-source-credit-program)
 
 # Donations
 


### PR DESCRIPTION
Some docs contain references to /wurstbrot/ private repo that are being automatically forwarded to /devsecopsmaturitymodel/ repo, probably due to renaming. 

This PR updates those references to the project repo. All links and images still work as expected.

