### PR TITLE
fix: update logo alt attribute to 'Home' per W3C standards

### DIFF
--- a/src/app/component/logo/logo.component.html
+++ b/src/app/component/logo/logo.component.html
@@ -1,3 +1,3 @@
 <div>
-  <img class="logo" src="assets/images/logo.png" />
+  <img class="logo" src="assets/images/logo.png" alt="Home" />
 </div>


### PR DESCRIPTION
fix: update logo alt attribute to meet W3C standards

Summary
This PR introduces a minor accessibility improvement to the main logo, directly addressing the feedback provided in #516 and adhering to W3C guidelines.

Changes Made

Replaced the missing/descriptive alt text with alt="Home" based on the [W3C Image Tutorial for Linked Logos](https://www.w3.org/WAI/tutorials/images/decision-tree/).

Ensured no unrelated formatting or linting changes were included to maintain a tidy commit history.

Verification

Before image
<img width="1321" height="594" alt="image" src="https://github.com/user-attachments/assets/e22637b3-115d-4925-bcc0-a817f4e951e4" />

After image
<img width="1319" height="597" alt="Screenshot 2026-03-26 094139" src="https://github.com/user-attachments/assets/a8986b4b-5906-4be5-88fe-516ea2cfa464" />

Please let me know if any additional refinements are needed.