### PR TITLE
fix: add ngOnDestroy to DependencyGraphComponent to prevent memory leak

### DIFF
--- a/src/app/component/dependency-graph/dependency-graph.component.ts
+++ b/src/app/component/dependency-graph/dependency-graph.component.ts
@@ -1,5 +1,7 @@
-import { Component, OnInit, Input, ElementRef, SimpleChanges, OnChanges } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input, ElementRef, SimpleChanges, OnChanges } from '@angular/core';
 import * as d3 from 'd3';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { LoaderService } from '../../service/loader/data-loader.service';
 import { Activity } from 'src/app/model/activity-store';
 import { DataStore } from 'src/app/model/data-store';
@@ -38,7 +40,8 @@ interface ThemeColors {
   templateUrl: './dependency-graph.component.html',
   styleUrls: ['./dependency-graph.component.css'],
 })
-export class DependencyGraphComponent implements OnInit, OnChanges {
+export class DependencyGraphComponent implements OnInit, OnChanges, OnDestroy {
+  private destroy$ = new Subject<void>();
   css: CSSStyleDeclaration = getComputedStyle(document.body);
   themeColors: Partial<ThemeColors> = {};
   theme: string;
@@ -66,9 +69,17 @@ export class DependencyGraphComponent implements OnInit, OnChanges {
     });
 
     // Reactively handle theme changes (if user toggles later)
-    this.themeService.theme$.subscribe((theme: string) => {
+    this.themeService.theme$.pipe(takeUntil(this.destroy$)).subscribe((theme: string) => {
       this.setThemeColors(theme);
     });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    if (this.simulation) {
+      this.simulation.stop();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
## What was the problem

DependencyGraphComponent implements OnInit and OnChanges but had no ngOnDestroy. This caused two things to keep running in memory even after the component was destroyed:
1. The theme service subscription was never unsubscribed
2. The D3 force simulation was never stopped on destroy

I tested this by taking heap snapshots before and after opening/closing the dependency graph 5-6 times. Memory went from 55.4 MB to 75.9 MB. In the comparison view <td> nodes showed 5,184 created and 0 deleted means DOM nodes were stacking up and never getting freed.

## What this PR does

1. Adds OnDestroy to the class
2. Adds a destroy$ Subject
3. Pipes the theme subscription through takeUntil(this.destroy$) so it auto unsubscribes
4. Calls this.simulation.stop() in ngOnDestroy

This is the same pattern already used in CircularHeatmapComponent so it is consistent with the existing codebase.

## Testing

After the fix, the <td> delta dropped from 5,184 unfreed nodes to 0, and Comment nodes went from +9,487 delta to 0. The theme subscription and D3 simulation are now properly cleaned up when the component is destroyed.

<img width="807" height="424" alt="Screenshot 2026-03-28 at 1 33 11 AM" src="https://github.com/user-attachments/assets/d22fe58c-6718-41b7-b608-e9a8c9c7d9a8" />


## Closes: #522 