### PR TITLE
fix: team group filter chip cannot be deselected on heatmap

### DIFF
--- a/src/app/component/dependency-graph/dependency-graph.component.ts
+++ b/src/app/component/dependency-graph/dependency-graph.component.ts
@@ -1,5 +1,7 @@
-import { Component, OnInit, Input, ElementRef, SimpleChanges, OnChanges } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input, ElementRef, SimpleChanges, OnChanges } from '@angular/core';
 import * as d3 from 'd3';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { LoaderService } from '../../service/loader/data-loader.service';
 import { Activity } from 'src/app/model/activity-store';
 import { DataStore } from 'src/app/model/data-store';
@@ -38,7 +40,8 @@ interface ThemeColors {
   templateUrl: './dependency-graph.component.html',
   styleUrls: ['./dependency-graph.component.css'],
 })
-export class DependencyGraphComponent implements OnInit, OnChanges {
+export class DependencyGraphComponent implements OnInit, OnChanges, OnDestroy {
+  private destroy$ = new Subject<void>();
   css: CSSStyleDeclaration = getComputedStyle(document.body);
   themeColors: Partial<ThemeColors> = {};
   theme: string;
@@ -66,9 +69,17 @@ export class DependencyGraphComponent implements OnInit, OnChanges {
     });
 
     // Reactively handle theme changes (if user toggles later)
-    this.themeService.theme$.subscribe((theme: string) => {
+    this.themeService.theme$.pipe(takeUntil(this.destroy$)).subscribe((theme: string) => {
       this.setThemeColors(theme);
     });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    if (this.simulation) {
+      this.simulation.stop();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/app/pages/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/pages/circular-heatmap/circular-heatmap.component.ts
@@ -226,7 +226,11 @@ export class CircularHeatmapComponent implements OnInit, OnDestroy {
       this.hasTeamsFilter = Object.values(this.filtersTeams).some(v => v === true);
       this.reColorHeatmap();
     } else {
-      console.log(`${perfNow()}: Heat: Chip flip Group '${teamGroup}: already on`);
+      chip.toggleSelected();
+      Object.keys(this.filtersTeams).forEach(key => (this.filtersTeams[key] = false));
+      this.hasTeamsFilter = false;
+      this.sectorService.setVisibleTeams([]);
+      this.reColorHeatmap();
     }
   }
 


### PR DESCRIPTION
## Problem

On the heatmap page, once a team group chip (e.g. "Customer", "Internal" etc.) is selected there is no way to deselect it. Clicking it again does nothing the chip stays permanently stuck in the selected state.

## Root Cause

In toggleTeamGroupFilter() inside circular-heatmap.component.ts, the else branch (which runs when the chip is already selected) only had a console.log and returned immediately. There was no deselection logic.

## Fix

Added deselection logic in the else block. When you click an already selected chip it now toggles off, clears all team filters, resets hasTeamsFilter and recolours the heatmap consistent with how individual team chips behave.

## Reviewers 
@vbakke @wurstbrot 
## Closes #524 