### PR TITLE
Fix typo in Image Metadata Collector description

### DIFF
--- a/src/assets/YAML/default/model.yaml
+++ b/src/assets/YAML/default/model.yaml
@@ -447,7 +447,7 @@ Build and Deployment:
         - kubernetes
         url: https://github.com/SDA-SE/image-metadata-collector/
         description: |
-          Collects namespaces and namespaces including responsible team and contact info through annotations/labels from Kubernetes clusters. Results are available in JSON and can be uploaded to S3, github and an API.
+          Collects namespaces and images including responsible team and contact info through annotations/labels from Kubernetes clusters. Results are available in JSON and can be uploaded to S3, GitHub and an API.
       references:
         samm2:
         - I-SB-B-1


### PR DESCRIPTION
- Change "Collects namespaces and namespaces" to "Collects namespaces and images"
- Fix capitalization in GitHub